### PR TITLE
Improved removal of egg-related files in Makefile

### DIFF
--- a/{{cookiecutter.repo_name}}/Makefile
+++ b/{{cookiecutter.repo_name}}/Makefile
@@ -17,7 +17,8 @@ clean: clean-build clean-pyc
 clean-build:
 	rm -fr build/
 	rm -fr dist/
-	rm -fr *.egg-info
+	find . -name '*.egg-info' -exec rm -fr {} +
+	find . -name '*.egg' -exec rm -f {} +
 
 clean-pyc:
 	find . -name '*.pyc' -exec rm -f {} +

--- a/{{cookiecutter.repo_name}}/Makefile
+++ b/{{cookiecutter.repo_name}}/Makefile
@@ -17,6 +17,7 @@ clean: clean-build clean-pyc
 clean-build:
 	rm -fr build/
 	rm -fr dist/
+	rm -fr .eggs/
 	find . -name '*.egg-info' -exec rm -fr {} +
 	find . -name '*.egg' -exec rm -f {} +
 


### PR DESCRIPTION
The current implementation does not remove any ``.egg`` files that ~~``tox``~~ ``python setup.py test`` adds to the root folder when it installs dependencies defined in ``setup.py``. I've amended the script to remove any and all ``.egg`` files when cleaning.

I also have a single-module Python project, which has a ``setup.py`` which looks like this:

    setup(
        [...]
        py_modules=[
            'package-name',
        ],
        package_dir={'':
                     'src'},
        [...]
    )

Though perhaps a bug with ``setuptools``, this adds the ``egginfo`` folder to the ``src`` directory, rather than to the root directory. The script now also removes any and all ``egginfo`` folders.