### PR TITLE
Use double quote to avoid broken strings

### DIFF
--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -22,9 +22,9 @@ test_requirements = [
 setup(
     name='{{ cookiecutter.repo_name }}',
     version='{{ cookiecutter.version }}',
-    description='{{ cookiecutter.project_short_description }}',
+    description="{{ cookiecutter.project_short_description }}",
     long_description=readme + '\n\n' + history,
-    author='{{ cookiecutter.full_name }}',
+    author="{{ cookiecutter.full_name }}",
     author_email='{{ cookiecutter.email }}',
     url='https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.repo_name }}',
     packages=[


### PR DESCRIPTION
Use double quote to avoid broken strings in the .py file if description or author name contains a single quote.