### PR TITLE
Using webbrowser module instead of Mac-only open to open user's browser

### DIFF
--- a/{{cookiecutter.repo_name}}/Makefile
+++ b/{{cookiecutter.repo_name}}/Makefile
@@ -1,4 +1,5 @@
 .PHONY: clean-pyc clean-build docs clean
+BROWSER := python -c 'import urllib, os, webbrowser, sys; webbrowser.open("file://" + urllib.pathname2url(os.path.abspath(sys.argv[1])))'
 
 help:
 	@echo "clean - remove all build, test, coverage and Python artifacts"
@@ -47,7 +48,7 @@ coverage:
 	coverage run --source {{ cookiecutter.repo_name }} setup.py test
 	coverage report -m
 	coverage html
-	python -m webbrowser htmlcov/index.html
+	$(BROWSER) htmlcov/index.html
 
 docs:
 	rm -f docs/{{ cookiecutter.repo_name }}.rst
@@ -55,7 +56,7 @@ docs:
 	sphinx-apidoc -o docs/ {{ cookiecutter.repo_name }}
 	$(MAKE) -C docs clean
 	$(MAKE) -C docs html
-	python -m webbrowser docs/_build/html/index.html
+	$(BROWSER) docs/_build/html/index.html
 
 release: clean
 	python setup.py sdist upload

--- a/{{cookiecutter.repo_name}}/Makefile
+++ b/{{cookiecutter.repo_name}}/Makefile
@@ -1,5 +1,15 @@
 .PHONY: clean-pyc clean-build docs clean
-BROWSER := python -c 'import urllib, os, webbrowser, sys; webbrowser.open("file://" + urllib.pathname2url(os.path.abspath(sys.argv[1])))'
+define BROWSER_PYSCRIPT
+import os, webbrowser, sys
+try:
+	from urllib import pathname2url
+except:
+	from urllib.request import pathname2url
+
+webbrowser.open("file://" + pathname2url(os.path.abspath(sys.argv[1])))
+endef
+export BROWSER_PYSCRIPT
+BROWSER := python -c "$$BROWSER_PYSCRIPT"
 
 help:
 	@echo "clean - remove all build, test, coverage and Python artifacts"

--- a/{{cookiecutter.repo_name}}/Makefile
+++ b/{{cookiecutter.repo_name}}/Makefile
@@ -47,7 +47,7 @@ coverage:
 	coverage run --source {{ cookiecutter.repo_name }} setup.py test
 	coverage report -m
 	coverage html
-	open htmlcov/index.html
+	python -m webbrowser htmlcov/index.html
 
 docs:
 	rm -f docs/{{ cookiecutter.repo_name }}.rst
@@ -55,7 +55,7 @@ docs:
 	sphinx-apidoc -o docs/ {{ cookiecutter.repo_name }}
 	$(MAKE) -C docs clean
 	$(MAKE) -C docs html
-	open docs/_build/html/index.html
+	python -m webbrowser docs/_build/html/index.html
 
 release: clean
 	python setup.py sdist upload


### PR DESCRIPTION
Hello,
Here is a proposal for using `python -m webbrowser` to open user's browser for the commands in `Makefile`, which seems to be more portable than the Mac-only command.
Is this any good?
Thank you!

PS: btw, thanks for this awesome project, I've used to release a few packages already and it made everything so much easier. so, thank you! <3