### PR TITLE
Read requirements from requirements.txt and add to install_requires

### DIFF
--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from pip.req import parse_requirements
+from pip.download import PipSession
 
 try:
     from setuptools import setup
@@ -14,7 +16,9 @@ with open('README.rst') as readme_file:
 with open('HISTORY.rst') as history_file:
     history = history_file.read().replace('.. :changelog:', '')
 
-requirements = [
+pip_reqs = parse_requirements("requirements.txt", session=PipSession())
+
+requirements = pip_reqs + [
     # TODO: put package requirements here
 ]
 


### PR DESCRIPTION
It is possible to use this layout for private repo/or add git link
to requirements or some one can run `python setup.py develop`.
In those case all requirements should be installed.