### PR TITLE
Add make servedocs to watch for changes and recompile docs

### DIFF
--- a/{{cookiecutter.repo_name}}/Makefile
+++ b/{{cookiecutter.repo_name}}/Makefile
@@ -68,6 +68,9 @@ docs:
 	$(MAKE) -C docs html
 	$(BROWSER) docs/_build/html/index.html
 
+servedocs: docs
+	watchmedo shell-command -p '*.rst' -c '$(MAKE) -C docs html' -R -D .
+
 release: clean
 	python setup.py sdist upload
 	python setup.py bdist_wheel upload

--- a/{{cookiecutter.repo_name}}/requirements_dev.txt
+++ b/{{cookiecutter.repo_name}}/requirements_dev.txt
@@ -1,2 +1,3 @@
 bumpversion==0.5.3
 wheel==0.23.0
+watchdog==0.8.3


### PR DESCRIPTION
Hey @audreyr,

This adds a `make servedocs` target that does what `make docs` do and then watch for changes in the docs recompiling whenever you save.
It uses the `watchmedo` utility from the [watchdog](https://pypi.python.org/pypi/watchdog) package available in PyPI.

I've been using it in a few projects for a while, it has proved handy. :)

Does this look good?

Thanks,
Elias