### PR TITLE
Fix build and simplify Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,9 @@ python:
   - "2.7"
   - "pypy"
 
-before_install:
+install:
   - pip install cookiecutter
+
+script:
   - cookiecutter . --no-input
-
-# command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
-install: pip install -r ./boilerplate/requirements.txt
-
-script: cd ./boilerplate && python setup.py test
+  - cd ./boilerplate && python setup.py test


### PR DESCRIPTION
Hey @audreyr,

This fixes the build and cleans up `.travis.yml`: since boilerplate requirements file is only dev requirements, we can assume boilerplate has no runtime deps and so no need to install them anymore.

Looks good?