### PR TITLE
Switchable py.test support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,15 @@ nosetests.xml
 .project
 .pydevproject
 
+# IntelliJ Idea family of suites
+.idea
+*.iml
+## File-based project format:
+*.ipr
+*.iws
+## mpeltonen/sbt-idea plugin
+.idea_modules/
+
 # Complexity
 output/*.html
 output/*/index.html

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,8 @@ install:
 
 script:
   - cookiecutter . --no-input
+{% if cookiecutter.use_pytest == 'y' -%}
+  - cd ./python_boilerplate && py.test
+{% else %}
   - cd ./python_boilerplate && python setup.py test
+{% endif %}

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ cookiecutter-pypackage
 Cookiecutter template for a Python package. See https://github.com/audreyr/cookiecutter.
 
 * Free software: BSD license
-* Vanilla testing setup with `unittest` and `python setup.py test`
+* Vanilla testing setup with `unittest` and `python setup.py test` or `py.test`
 * Travis-CI_: Ready for Travis Continuous Integration testing
 * Tox_ testing: Setup to easily test for Python 2.6, 2.7, 3.3, 3.4
 * Sphinx_ docs: Documentation ready for generation with, for example, ReadTheDocs_

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -9,5 +9,6 @@
 	"pypi_username": "{{ cookiecutter.github_username }}",
 	"year": "2015",
 	"version": "0.1.0",
+	"use_pytest": "n",
 	"use_pypi_deployment_with_travis": "y"
 }

--- a/{{cookiecutter.project_slug}}/CONTRIBUTING.rst
+++ b/{{cookiecutter.project_slug}}/CONTRIBUTING.rst
@@ -77,7 +77,7 @@ Ready to contribute? Here's how to set up `{{ cookiecutter.project_slug }}` for 
 5. When you're done making changes, check that your changes pass flake8 and the tests, including testing other Python versions with tox::
 
     $ flake8 {{ cookiecutter.project_slug }} tests
-    $ python setup.py test
+    $ python setup.py test or py.test
     $ tox
 
    To get flake8 and tox, just pip install them into your virtualenv.
@@ -108,4 +108,8 @@ Tips
 
 To run a subset of tests::
 
+{% if cookiecutter.use_pytest == 'y' -%}
+    $ py.test tests.test_{{ cookiecutter.project_slug }}
+{% else %}
     $ python -m unittest tests.test_{{ cookiecutter.project_slug }}
+{%- endif %}

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -49,13 +49,21 @@ lint:
 	flake8 {{ cookiecutter.project_slug }} tests
 
 test:
+{% if cookiecutter.use_pytest == 'y' -%}
+	py.test
+{% else %}
 	python setup.py test
+{%- endif %}
 
 test-all:
 	tox
 
 coverage:
+{% if cookiecutter.use_pytest == 'y' -%}
+	coverage run --source {{ cookiecutter.project_slug }} py.test
+{% else %}
 	coverage run --source {{ cookiecutter.project_slug }} setup.py test
+{% endif %}
 	coverage report -m
 	coverage html
 	$(BROWSER) htmlcov/index.html

--- a/{{cookiecutter.project_slug}}/requirements_dev.txt
+++ b/{{cookiecutter.project_slug}}/requirements_dev.txt
@@ -7,5 +7,6 @@ coverage==4.0
 Sphinx==1.3.1
 {% if cookiecutter.use_pypi_deployment_with_travis == 'y' -%}
 cryptography==1.0.1
-PyYAML==3.11
-{% endif %}
+PyYAML==3.11{% endif %}
+{% if cookiecutter.use_pytest == 'y' -%}
+pytest==2.8.3{%- endif %}

--- a/{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py
+++ b/{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py
@@ -8,11 +8,28 @@ test_{{ cookiecutter.project_slug }}
 Tests for `{{ cookiecutter.project_slug }}` module.
 """
 
+{% if cookiecutter.use_pytest == 'y' -%}
+import pytest
+{% else %}
 import unittest
+{%- endif %}
 
 from {{ cookiecutter.project_slug }} import {{ cookiecutter.project_slug }}
 
+{% if cookiecutter.use_pytest == 'y' -%}
+class Test{{ cookiecutter.repo_name|capitalize }}(object):
 
+    @classmethod
+    def setup_class(cls):
+        pass
+
+    def test_something(self):
+        pass
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+{% else %}
 class Test{{ cookiecutter.project_slug|capitalize }}(unittest.TestCase):
 
     def setUp(self):
@@ -28,3 +45,4 @@ class Test{{ cookiecutter.project_slug|capitalize }}(unittest.TestCase):
 if __name__ == '__main__':
     import sys
     sys.exit(unittest.main())
+{%- endif %}

--- a/{{cookiecutter.project_slug}}/tox.ini
+++ b/{{cookiecutter.project_slug}}/tox.ini
@@ -4,7 +4,14 @@ envlist = py26, py27, py33, py34, py35
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/{{ cookiecutter.project_slug }}
+{% if cookiecutter.use_pytest == 'y' -%}
+deps =
+    -r{toxinidir}/requirements_dev.txt
+commands =
+    py.test --basetemp={envtmpdir}
+{% else %}
 commands = python setup.py test
+{%- endif %}
 
 ; If you want to make tox run the tests with the same versions, create a
 ; requirements.txt with the pinned versions and uncomment the following lines:


### PR DESCRIPTION
I have added an option to the `cookiecutter.json` to switch between py.test and the regular test setup. I have been using this for my own projects and it seems to be a often heard feature request.