### PR TITLE
travis_pypi_setup fails on python 3

### DIFF
--- a/{{cookiecutter.project_slug}}/travis_pypi_setup.py
+++ b/{{cookiecutter.project_slug}}/travis_pypi_setup.py
@@ -58,7 +58,10 @@ def fetch_public_key(repo):
     Travis API docs: http://docs.travis-ci.com/api/#repository-keys
     """
     keyurl = 'https://api.travis-ci.org/repos/{0}/key'.format(repo)
-    data = json.loads(urlopen(keyurl).read().decode())
+    raw_data = urlopen(keyurl).read()
+    if sys.version_info >= (3, 0):
+        raw_data = raw_data.decode("utf-8")
+    data = json.loads(raw_data)
     if 'key' not in data:
         errmsg = "Could not find public key for repo: {}.\n".format(repo)
         errmsg += "Have you already added your GitHub repo to Travis?"

--- a/{{cookiecutter.project_slug}}/travis_pypi_setup.py
+++ b/{{cookiecutter.project_slug}}/travis_pypi_setup.py
@@ -13,6 +13,7 @@ import yaml
 from cryptography.hazmat.primitives.serialization import load_pem_public_key
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric.padding import PKCS1v15
+import sys
 
 
 try:


### PR DESCRIPTION
    Traceback (most recent call last):
      File "travis_pypi_setup.py", line 122, in <module>
        main(args)
     File "travis_pypi_setup.py", line 107, in main
       public_key = fetch_public_key(args.repo)
     File "travis_pypi_setup.py", line 61, in fetch_public_key
       data = json.loads(urlopen(keyurl).read())
     File     "/usr/local/Cellar/python3/3.4.2_1/Frameworks/Python.framework/Versions/3.4/lib/python3.4/json/__init_.py", line 312, in loads
    s.__class__.__name__))
    TypeError: the JSON object must be str, not 'bytes'

I did a quick fix by decoding the raw data, see commit.

This brings me to the password prompt

    PyPI password:
    Traceback (most recent call last):
      File "travis_pypi_setup.py", line 122, in <module>
        main(args)
      File "travis_pypi_setup.py", line 109, in main
       update_travis_deploy_password(encrypt(public_key, password))
      File "travis_pypi_setup.py", line 51, in encrypt
        encrypted_password = key.encrypt(password, PKCS1v15())
      File "/Users/j/dev/.virtualenvs/pyup-py3/lib/python3.4/site-    packages/cryptography/hazmat/backends/openssl/rsa.py", line 590, in encrypt
        return _enc_dec_rsa(self._backend, self, plaintext, padding)
      File "/Users/j/dev/.virtualenvs/pyup-py3/lib/python3.4/site-packages/cryptography/hazmat/backends/openssl/rsa.py", line 76, in _enc_dec_rsa
    return _enc_dec_rsa_pkey_ctx(backend, key, data, padding_enum)
      File "/Users/j/dev/.virtualenvs/pyup-py3/lib/python3.4/site-packages/cryptography/hazmat/backends/openssl/rsa.py", line 103, in _enc_dec_rsa_pkey_ctx
    res = crypt(pkey_ctx, buf, outlen, data, len(data))
    TypeError: initializer for ctype 'unsigned char *' must be a bytes or list or tuple, not str

That's a regression error in [pyopenssl](https://github.com/pyca/pyopenssl/issues/15) that should get fixed with the next release.