### PR TITLE
Add Flake8 exclude for sphinx config

### DIFF
--- a/{{cookiecutter.project_slug}}/setup.cfg
+++ b/{{cookiecutter.project_slug}}/setup.cfg
@@ -9,3 +9,6 @@ tag = True
 
 [wheel]
 universal = 1
+
+[flake8]
+exclude = docs


### PR DESCRIPTION
Otherwise you get a heap of noise:
```
./docs/conf.py:23:1: E265 block comment should start with '# '
./docs/conf.py:39:1: E265 block comment should start with '# '
./docs/conf.py:52:1: E265 block comment should start with '# '
./docs/conf.py:72:1: E265 block comment should start with '# '
./docs/conf.py:76:1: E265 block comment should start with '# '
./docs/conf.py:78:1: E265 block comment should start with '# '
./docs/conf.py:86:1: E265 block comment should start with '# '
./docs/conf.py:89:1: E265 block comment should start with '# '
./docs/conf.py:93:1: E265 block comment should start with '# '
./docs/conf.py:97:1: E265 block comment should start with '# '
./docs/conf.py:103:1: E265 block comment should start with '# '
./docs/conf.py:107:1: E265 block comment should start with '# '
./docs/conf.py:119:1: E265 block comment should start with '# '
./docs/conf.py:122:1: E265 block comment should start with '# '
./docs/conf.py:126:1: E265 block comment should start with '# '
./docs/conf.py:130:1: E265 block comment should start with '# '
./docs/conf.py:134:1: E265 block comment should start with '# '
./docs/conf.py:139:1: E265 block comment should start with '# '
./docs/conf.py:149:1: E265 block comment should start with '# '
./docs/conf.py:153:1: E265 block comment should start with '# '
./docs/conf.py:156:1: E265 block comment should start with '# '
./docs/conf.py:160:1: E265 block comment should start with '# '
./docs/conf.py:163:1: E265 block comment should start with '# '
./docs/conf.py:166:1: E265 block comment should start with '# '
./docs/conf.py:169:1: E265 block comment should start with '# '
./docs/conf.py:172:1: E265 block comment should start with '# '
./docs/conf.py:176:1: E265 block comment should start with '# '
./docs/conf.py:180:1: E265 block comment should start with '# '
./docs/conf.py:185:1: E265 block comment should start with '# '
./docs/conf.py:188:1: E265 block comment should start with '# '
./docs/conf.py:198:5: E265 block comment should start with '# '
./docs/conf.py:201:5: E265 block comment should start with '# '
./docs/conf.py:204:5: E265 block comment should start with '# '
./docs/conf.py:218:1: E265 block comment should start with '# '
./docs/conf.py:222:1: E265 block comment should start with '# '
./docs/conf.py:225:1: E265 block comment should start with '# '
./docs/conf.py:228:1: E265 block comment should start with '# '
./docs/conf.py:231:1: E265 block comment should start with '# '
./docs/conf.py:234:1: E265 block comment should start with '# '
./docs/conf.py:248:1: E265 block comment should start with '# '
./docs/conf.py:266:1: E265 block comment should start with '# '
./docs/conf.py:269:1: E265 block comment should start with '# '
./docs/conf.py:272:1: E265 block comment should start with '# '
./docs/conf.py:275:1: E265 block comment should start with '# '
```