### PR TITLE
Add more complete installation instructions

### DIFF
--- a/{{cookiecutter.project_slug}}/docs/installation.rst
+++ b/{{cookiecutter.project_slug}}/docs/installation.rst
@@ -4,15 +4,46 @@
 Installation
 ============
 
-At the command line:
+
+Stable release
+--------------
+
+To install {{ cookiecutter.project_name }}, run this command in your terminal:
 
 .. code-block:: console
 
-    $ easy_install {{ cookiecutter.project_slug }}
-
-Or, if you have virtualenvwrapper installed:
-
-.. code-block:: console
-
-    $ mkvirtualenv {{ cookiecutter.project_slug }}
     $ pip install {{ cookiecutter.project_slug }}
+
+If you don't have `pip`_ installed, this `Python installation guide`_ can guide
+you through the process.
+
+.. _pip: https://pip.pypa.io
+.. _Python installation guide: http://docs.python-guide.org/en/latest/starting/installation/
+
+
+From sources
+------------
+
+The sources for {{ cookiecutter.project_name }} can be downloaded from the `Github repo`_.
+
+You can either clone the public repository:
+
+.. code-block:: console
+
+    $ git clone git://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}
+
+Or download the `tarball`_:
+
+.. code-block:: console
+
+    $ curl  -OL https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}/tarball/master
+
+Once you have a copy of the source, you can install it with:
+
+.. code-block:: console
+
+    $ python setup.py install
+
+
+.. _Github repo: https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}
+.. _tarball: https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}/tarball/master


### PR DESCRIPTION
Proposing more complete installation docs, suggesting pip install for
the stable releases and `python setup.py install` for installation from
sources.

For people that don't have pip, we point them to the Python installation in the hitchhiker's guide, that has nice instructions for having the basics (setuptools, pip and virtualenv): http://docs.python-guide.org/en/latest/starting/installation/