### PR TITLE
Do not use removed repo_name in PyTest template

### DIFF
--- a/{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py
+++ b/{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py
@@ -17,7 +17,7 @@ import unittest
 from {{ cookiecutter.project_slug }} import {{ cookiecutter.project_slug }}
 
 {% if cookiecutter.use_pytest == 'y' -%}
-class Test{{ cookiecutter.repo_name|capitalize }}(object):
+class Test{{ cookiecutter.project_slug|title }}(object):
 
     @classmethod
     def setup_class(cls):
@@ -30,7 +30,7 @@ class Test{{ cookiecutter.repo_name|capitalize }}(object):
     def teardown_class(cls):
         pass
 {% else %}
-class Test{{ cookiecutter.project_slug|capitalize }}(unittest.TestCase):
+class Test{{ cookiecutter.project_slug|title }}(unittest.TestCase):
 
     def setUp(self):
         pass


### PR DESCRIPTION
`repo_name` does not exist.

Don't know if changing from `capitalize` to `title` has a point, but it seems to work fine.