### PR TITLE
Improve bumpversion regex matching

### DIFF
--- a/{{cookiecutter.project_slug}}/setup.cfg
+++ b/{{cookiecutter.project_slug}}/setup.cfg
@@ -4,8 +4,12 @@ commit = True
 tag = True
 
 [bumpversion:file:setup.py]
+search = version='{current_version}'
+replace = version='{new_version}'
 
 [bumpversion:file:{{ cookiecutter.project_slug }}/__init__.py]
+search = __version__ = '{current_version}'
+replace = __version__ = '{new_version}'
 
 [wheel]
 universal = 1


### PR DESCRIPTION
With current configuration, bumpversion will find&replace any occurrence of the version number in setup.py and my_project/init.py

This leads to trouble typically when setup.py mentions a dependency which has by hazard the same version number as our project (thus the dependency will get it version upped)

This fix precises to bumpversion a regex to match in the files in order to prevent such mistake.