### PR TITLE
Remove PyPy from default Travis environments.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py35, pypy
+envlist = py27, py33, py34, py35
 skipsdist = true
 
 [testenv]


### PR DESCRIPTION
A Travis build on PyPy for an unmodified cookiecutter-pypackage install will fail because it can't install the cryptography dependency. Cryptography will support the next release of PyPy but for the time being cookiecutter-pypackage can't be used on PyPy.

This is an example of a failing build: https://travis-ci.org/1337807/markovian/jobs/134879940

I initially tried using the 'pypy3' tox default environment instead of 'pypy' but that failed as well: https://travis-ci.org/1337807/markovian/jobs/134885538

I spoke with @alex an confirmed that cryptography does not support any presently released versions of PyPy. It will however support the next released version of PyPy 3 so I'm adding an issue for someone to come back and add this environment again.