### PR TITLE
include support for choosing between multiple licenses

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -8,5 +8,6 @@
 	"pypi_username": "{{ cookiecutter.github_username }}",
 	"version": "0.1.0",
 	"use_pytest": "n",
-	"use_pypi_deployment_with_travis": "y"
+	"use_pypi_deployment_with_travis": "y",
+	"open_source_license": ["MIT", "BSD", "Not open source"]
 }

--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -53,7 +53,7 @@ def test_year_compute_in_license_file(cookies):
     result = cookies.bake()
     license_file_path = result.project.join('LICENSE')
     now = datetime.datetime.now()
-    assert str(now.year) in license_file_path.readlines()[0]
+    assert str(now.year) in license_file_path.read()
 
 
 def test_bake_with_defaults(cookies):
@@ -107,3 +107,11 @@ def test_make_help(cookies):
         output = check_output_inside_dir('make help', str(result.project))
         assert b"check code coverage quickly with the default Python" in output
 
+def test_bake_selecting_license(cookies):
+    license_strings = {
+        'MIT': 'MIT ',
+        'BSD': 'Redistributions of source code must retain the above copyright notice, this',
+    }
+    for license, target_string in license_strings.items():
+        with bake_in_temp_dir(cookies, extra_context={'open_source_license': license}) as result:
+            assert target_string in result.project.join('LICENSE').read()

--- a/{{cookiecutter.project_slug}}/LICENSE
+++ b/{{cookiecutter.project_slug}}/LICENSE
@@ -1,14 +1,39 @@
+{% if cookiecutter.open_source_license == 'MIT' %}
+MIT License
+
+Copyright (c) {% now 'local', '%Y' %}, {{ cookiecutter.full_name }}
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+{% elif cookiecutter.open_source_license == 'BSD' %}
 Copyright (c) {% now 'local', '%Y' %}, {{ cookiecutter.full_name }}
 All rights reserved.
 
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
 
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
-OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice, this
+  list of conditions and the following disclaimer in the documentation and/or
+  other materials provided with the distribution.
+
+* Neither the name of {{ cookiecutter.project_name }} nor the names of its
+  contributors may be used to endorse or promote products derived from this
+  software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+{% endif %}


### PR DESCRIPTION
This PR include support for choosing a license from a list of pre-defined ones. Currently, it only supports MIT and BSD, and MIT is the default one.

This PR solves https://github.com/audreyr/cookiecutter-pypackage/issues/62