### PR TITLE
Change readthedocs.org URLs to readthedocs.io.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,7 @@ make my own packaging experience better.
 .. _Travis-CI: http://travis-ci.org/
 .. _Tox: http://testrun.org/tox/
 .. _Sphinx: http://sphinx-doc.org/
-.. _ReadTheDocs: https://readthedocs.org/
+.. _ReadTheDocs: https://readthedocs.io/
 .. _`Nekroze/cookiecutter-pypackage`: https://github.com/Nekroze/cookiecutter-pypackage
 .. _`tony/cookiecutter-pypackage-pythonic`: https://github.com/tony/cookiecutter-pypackage-pythonic
 .. _`ardydedase/cookiecutter-pypackage`: https://github.com/ardydedase/cookiecutter-pypackage

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -120,7 +120,7 @@ Import the repository
 
 In your GitHub repo settings > Webhooks & services, turn on the ReadTheDocs service hook.
 
-.. _ `ReadTheDocs`: https://readthedocs.org/
+.. _ `ReadTheDocs`: https://readthedocs.io/
 
 Step 7: Release on PyPI
 ------------------------

--- a/{{cookiecutter.project_slug}}/README.rst
+++ b/{{cookiecutter.project_slug}}/README.rst
@@ -8,15 +8,15 @@
 .. image:: https://img.shields.io/travis/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}.svg
         :target: https://travis-ci.org/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}
 
-.. image:: https://readthedocs.org/projects/{{ cookiecutter.project_slug }}/badge/?version=latest
-        :target: https://readthedocs.org/projects/{{ cookiecutter.project_slug }}/?badge=latest
+.. image:: https://readthedocs.io/projects/{{ cookiecutter.project_slug }}/badge/?version=latest
+        :target: https://readthedocs.io/projects/{{ cookiecutter.project_slug }}/?badge=latest
         :alt: Documentation Status
 
 
 {{ cookiecutter.project_short_description}}
 
 * Free software: ISC license
-* Documentation: https://{{ cookiecutter.project_slug }}.readthedocs.org.
+* Documentation: https://{{ cookiecutter.project_slug }}.readthedocs.io.
 
 Features
 --------


### PR DESCRIPTION
@willingc pointed out that the URL for Read The Docs has changed from readthedocs.org to readthedocs.io.

This closes https://github.com/audreyr/cookiecutter-pypackage/issues/150