### PR TITLE
RequiresIO badges and documentation links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,8 @@ cookiecutter-pypackage
 
 .. image:: https://img.shields.io/travis/audreyr/cookiecutter-pypackage.svg
    :target: https://travis-ci.org/audreyr/cookiecutter-pypackage
-.. image:: https://requires.io/github/audreyr/cookiecutter-pypackage/requirements.svg?branch=default
-   :target: https://requires.io/github/audreyr/cookiecutter-pypackage/requirements?branch=default
+.. image:: https://requires.io/github/audreyr/cookiecutter-pypackage/requirements.svg?branch=master
+   :target: https://requires.io/github/audreyr/cookiecutter-pypackage/requirements?branch=master
    :alt: Dependencies
 
 Cookiecutter_ template for a Python package.

--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,9 @@ cookiecutter-pypackage
 
 .. image:: https://img.shields.io/travis/audreyr/cookiecutter-pypackage.svg
    :target: https://travis-ci.org/audreyr/cookiecutter-pypackage
+.. image:: https://requires.io/github/audreyr/cookiecutter-pypackage/requirements.svg?branch=default
+   :target: https://requires.io/github/audreyr/cookiecutter-pypackage/requirements?branch=default
+   :alt: Dependencies
 
 Cookiecutter_ template for a Python package.
 

--- a/README.rst
+++ b/README.rst
@@ -20,8 +20,8 @@ Features
 * Travis-CI_: Ready for Travis Continuous Integration testing
 * Tox_ testing: Setup to easily test for Python 2.6, 2.7, 3.3, 3.4, 3.5
 * Sphinx_ docs: Documentation ready for generation with, for example, ReadTheDocs_
-* Bumpversion: Pre-configured version bumping with a single command
-* Auto-release to PyPI when you push a new tag to master (optional)
+* Bumpversion_: Pre-configured version bumping with a single command
+* Auto-release to PyPI_ when you push a new tag to master (optional)
 
 .. _Cookiecutter: https://github.com/audreyr/cookiecutter
 
@@ -102,6 +102,8 @@ make my own packaging experience better.
 .. _Sphinx: http://sphinx-doc.org/
 .. _ReadTheDocs: https://readthedocs.org/
 .. _RequiresIO: https://requires.io/
+.. _Bumpversion: https://github.com/peritus/bumpversion
+.. _PyPi: https://pypi.python.org/pypi
 .. _`Nekroze/cookiecutter-pypackage`: https://github.com/Nekroze/cookiecutter-pypackage
 .. _`tony/cookiecutter-pypackage-pythonic`: https://github.com/tony/cookiecutter-pypackage-pythonic
 .. _`ardydedase/cookiecutter-pypackage`: https://github.com/ardydedase/cookiecutter-pypackage

--- a/README.rst
+++ b/README.rst
@@ -39,14 +39,18 @@ Generate a Python package project::
 Then:
 
 * Create a repo and put it there.
-* Add the repo to your Travis CI account.
+* Add the repo to your Travis-CI_ account.
 * Install the dev requirements into a virtualenv. (``pip install -r requirements_dev.txt``)
 * Run the script `travis_pypi_setup.py` to encrypt your PyPI password in Travis config
   and activate automated deployment on PyPI when you push a new tag to master branch.
-* Add the repo to your ReadTheDocs account + turn on the ReadTheDocs service hook.
+* Add the repo to your ReadTheDocs_ account + turn on the ReadTheDocs service hook.
 * Release your package by pushing a new tag to master.
-* (Optional) If you feel like pinning the requirements for your package, you can
-  add a `requirements.txt` that specifies packages and version numbers.
+* Add a `requirements.txt` file that specifies the packages you will need for
+  your project and their versions. For more information see the `pip documentation
+  for requirements files`_.
+* Activate your project on RequiresIO_.
+
+.. _`pip documentation for requirements files`: https://pip.pypa.io/en/stable/user_guide/#requirements-files
 
 For more details, see the `cookiecutter-pypackage tutorial`_.
 
@@ -97,6 +101,7 @@ make my own packaging experience better.
 .. _Tox: http://testrun.org/tox/
 .. _Sphinx: http://sphinx-doc.org/
 .. _ReadTheDocs: https://readthedocs.org/
+.. _RequiresIO: https://requires.io/
 .. _`Nekroze/cookiecutter-pypackage`: https://github.com/Nekroze/cookiecutter-pypackage
 .. _`tony/cookiecutter-pypackage-pythonic`: https://github.com/tony/cookiecutter-pypackage-pythonic
 .. _`ardydedase/cookiecutter-pypackage`: https://github.com/ardydedase/cookiecutter-pypackage

--- a/{{cookiecutter.project_slug}}/README.rst
+++ b/{{cookiecutter.project_slug}}/README.rst
@@ -12,8 +12,8 @@
         :target: https://readthedocs.org/projects/{{ cookiecutter.project_slug }}/?badge=latest
         :alt: Documentation Status
 
-.. image:: https://requires.io/github/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}/requirements.svg?branch=default
-        :target: https://requires.io/github/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}/requirements?branch=default
+.. image:: https://requires.io/github/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}/requirements.svg?branch=master
+        :target: https://requires.io/github/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}/requirements?branch=master
         :alt: Dependencies
 
 

--- a/{{cookiecutter.project_slug}}/README.rst
+++ b/{{cookiecutter.project_slug}}/README.rst
@@ -12,6 +12,10 @@
         :target: https://readthedocs.org/projects/{{ cookiecutter.project_slug }}/?badge=latest
         :alt: Documentation Status
 
+.. image:: https://requires.io/github/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}/requirements.svg?branch=default
+        :target: https://requires.io/github/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}/requirements?branch=default
+        :alt: Dependencies
+
 
 {{ cookiecutter.project_short_description}}
 


### PR DESCRIPTION
This adds the RequiresIO dependency badges to the README files and updates the documentation to include setup instructions. It also includes some links to sites that were mentioned already but didn't have associated URLs.

⚠️ Merge https://github.com/audreyr/cookiecutter-pypackage/pull/162 first so the new badge is green.

This closes https://github.com/audreyr/cookiecutter-pypackage/issues/147