### PR TITLE
Update tox and cryptography.

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,6 @@
 PyYAML==3.11
 pytest==2.9.2
-tox==2.1.1
-cryptography==1.0.1
+tox==2.3.1
+cryptography==1.3.4
 cookiecutter
 pytest-cookies


### PR DESCRIPTION
I've added RequiresIO badges (https://github.com/audreyr/cookiecutter-pypackage/pull/161) but the badge on the README is red because these dependencies are out of date. This should get us to green.