### PR TITLE
Add makefile with command to bake project watching for changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,4 +93,4 @@ target/
 
 # Cookiecutter
 output/
-boilerplate/
+python_boilerplate/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+help:
+	@echo "bake 	generate project using defaults"
+	@echo "watch 	generate project using defaults and watch for changes"
+
+bake:
+	cookiecutter --no-input . --overwrite-if-exists
+
+watch: bake
+	watchmedo shell-command -p '*.*' -c 'make bake' -W -R -D \{{cookiecutter.project_slug}}/

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,3 +4,4 @@ tox==2.3.1
 cryptography==1.3.4
 cookiecutter
 pytest-cookies
+watchdog


### PR DESCRIPTION
When we're doing changes in cookiecutter templates, we often have to generate an re-generate the project, to check if it's actually doing what we expect.

I wanted to try making this feedback loop a bit tigher, so I came up with this. The idea is, when you're editing the template, you'd do:

    make watch

This will run `cookiecutter --no-input . --overwrite-if-exists` right away, and then every time you change something inside the template directory. I was using it while working on #169 and I quite liked it.

There is room for improvements, some things I thought:

1) it would be nice to re-run the command also when cookiecutter.json changes, or any of the hook scripts too (I couldn't figure out how to do this properly with `watchmedo`, it only watches directories)
2) it would be nice to support running cookiecutter asking for input the first time and then with `--replay` the following times

What do you think?