### PR TITLE
Add GitHub issue template. Close #157

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,14 @@
+* Date you used Cookiecutter PyPackage:
+* Cookiecutter version used, if any:
+* Python version, if any:
+* Operating System:
+
+### Description
+
+Describe what you were trying to get done. Tell us what happened, what went wrong, and what you expected to happen.
+
+### What I Did
+
+```
+Paste the command(s) you ran and the output.
+```


### PR DESCRIPTION
This adds a GitHub Issue template to the main root of cookiecutter pypackage.