### PR TITLE
Fix indentation of authors in docs

### DIFF
--- a/{{cookiecutter.project_slug}}/docs/index.rst
+++ b/{{cookiecutter.project_slug}}/docs/index.rst
@@ -15,9 +15,7 @@ Contents:
    installation
    usage
    contributing
-   {% if cookiecutter.create_author_file == 'y' -%}
-      authors
-   {% endif -%}
+   {% if cookiecutter.create_author_file == 'y' %}authors{% endif %}
    history
 
 Indices and tables
@@ -26,4 +24,3 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-

--- a/{{cookiecutter.project_slug}}/docs/index.rst
+++ b/{{cookiecutter.project_slug}}/docs/index.rst
@@ -15,7 +15,7 @@ Contents:
    installation
    usage
    contributing
-   {% if cookiecutter.create_author_file == 'y' %}authors{% endif %}
+   {% if cookiecutter.create_author_file == 'y' -%}authors{% endif -%}
    history
 
 Indices and tables


### PR DESCRIPTION
Correct indentation of the generated toc tree in index.rst so it displays authors properly.