### PR TITLE
Add a link to the docs in README. Fix #192

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,6 +11,7 @@ Cookiecutter PyPackage
 Cookiecutter_ template for a Python package.
 
 * GitHub repo: https://github.com/audreyr/cookiecutter-pypackage/
+* Documentation: https://cookiecutter-pypackage.readthedocs.io/
 * Free software: BSD license
 
 Features


### PR DESCRIPTION
As cookiecutter-pypackage do for every other package.