### PR TITLE
Fix generated read-the-docs badge

### DIFF
--- a/{{cookiecutter.project_slug}}/README.rst
+++ b/{{cookiecutter.project_slug}}/README.rst
@@ -8,8 +8,8 @@
 .. image:: https://img.shields.io/travis/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}.svg
         :target: https://travis-ci.org/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}
 
-.. image:: https://readthedocs.io/projects/{{ cookiecutter.project_slug }}/badge/?version=latest
-        :target: https://readthedocs.io/projects/{{ cookiecutter.project_slug }}/?badge=latest
+.. image:: https://readthedocs.org/projects/{{ cookiecutter.project_slug }}/badge/?version=latest
+        :target: https://{{ cookiecutter.project_slug }}.readthedocs.io/en/latest/?badge=latest
         :alt: Documentation Status
 
 .. image:: https://requires.io/github/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}/requirements.svg?branch=master

--- a/{{cookiecutter.project_slug}}/README.rst
+++ b/{{cookiecutter.project_slug}}/README.rst
@@ -8,8 +8,8 @@
 .. image:: https://img.shields.io/travis/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}.svg
         :target: https://travis-ci.org/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}
 
-.. image:: https://readthedocs.org/projects/{{ cookiecutter.project_slug }}/badge/?version=latest
-        :target: https://{{ cookiecutter.project_slug }}.readthedocs.io/en/latest/?badge=latest
+.. image:: https://readthedocs.org/projects/{{ cookiecutter.project_slug | replace("_", "-") }}/badge/?version=latest
+        :target: https://{{ cookiecutter.project_slug | replace("_", "-") }}.readthedocs.io/en/latest/?badge=latest
         :alt: Documentation Status
 
 .. image:: https://requires.io/github/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}/requirements.svg?branch=master

--- a/{{cookiecutter.project_slug}}/README.rst
+++ b/{{cookiecutter.project_slug}}/README.rst
@@ -20,7 +20,7 @@
 {{ cookiecutter.project_short_description }}
 
 * Free software: {{ cookiecutter.open_source_license }}
-* Documentation: https://{{ cookiecutter.project_slug }}.readthedocs.io.
+* Documentation: https://{{ cookiecutter.project_slug | replace("_", "-") }}.readthedocs.io.
 
 Features
 --------


### PR DESCRIPTION
Read The Docs now uses .org for logins & badges. Also, they convert underscores in the repo name to dashes, sigh. They also changed the format for referencing the docs, to allow for different languages versions.