### PR TITLE
Add better handling for not open source (fixes #189)

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -17,5 +17,8 @@ if __name__ == '__main__':
         remove_file('docs/authors.rst')
 
     if 'no' in '{{ cookiecutter.command_line_interface|lower }}':
-        filepath = os.path.join('{{ cookiecutter.project_slug }}', 'cli.py')
-        remove_file(filepath)
+        cli_file = os.path.join('{{ cookiecutter.project_slug }}', 'cli.py')
+        remove_file(cli_file)
+
+    if 'Not open source' == '{{ cookiecutter.open_source_license }}':
+        remove_file('LICENSE')

--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -158,6 +158,14 @@ def test_bake_selecting_license(cookies):
             assert license in result.project.join('setup.py').read()
 
 
+def test_bake_not_open_source(cookies):
+    with bake_in_temp_dir(cookies, extra_context={'open_source_license': 'Not open source'}) as result:
+        found_toplevel_files = [f.basename for f in result.project.listdir()]
+        assert 'setup.py' in found_toplevel_files
+        assert 'LICENSE' not in found_toplevel_files
+        assert 'License' not in result.project.join('README.rst').read()
+
+
 def test_using_pytest(cookies):
     with bake_in_temp_dir(cookies, extra_context={'use_pytest': 'y'}) as result:
         assert result.project.isdir()

--- a/{{cookiecutter.project_slug}}/README.rst
+++ b/{{cookiecutter.project_slug}}/README.rst
@@ -1,7 +1,9 @@
+{% set is_open_source = cookiecutter.open_source_license != 'Not open source' %}
 ===============================
 {{ cookiecutter.project_name }}
 ===============================
 
+{% if is_open_source %}
 .. image:: https://img.shields.io/pypi/v/{{ cookiecutter.project_slug }}.svg
         :target: https://pypi.python.org/pypi/{{ cookiecutter.project_slug }}
 
@@ -11,6 +13,7 @@
 .. image:: https://readthedocs.org/projects/{{ cookiecutter.project_slug | replace("_", "-") }}/badge/?version=latest
         :target: https://{{ cookiecutter.project_slug | replace("_", "-") }}.readthedocs.io/en/latest/?badge=latest
         :alt: Documentation Status
+{%- endif %}
 
 .. image:: https://requires.io/github/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}/requirements.svg?branch=master
         :target: https://requires.io/github/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}/requirements?branch=master
@@ -19,8 +22,10 @@
 
 {{ cookiecutter.project_short_description }}
 
+{% if is_open_source %}
 * Free software: {{ cookiecutter.open_source_license }}
 * Documentation: https://{{ cookiecutter.project_slug | replace("_", "-") }}.readthedocs.io.
+{% endif %}
 
 Features
 --------

--- a/{{cookiecutter.project_slug}}/README.rst
+++ b/{{cookiecutter.project_slug}}/README.rst
@@ -1,4 +1,4 @@
-{% set is_open_source = cookiecutter.open_source_license != 'Not open source' %}
+{% set is_open_source = cookiecutter.open_source_license != 'Not open source' -%}
 ===============================
 {{ cookiecutter.project_name }}
 ===============================


### PR DESCRIPTION
This removes the LICENSE file and omit badges and links for
ReadTheDocs, Travis and PyPI when project is not open source.

Looks good?