### PR TITLE
Specify minimal cookiecutter version (closes #194)

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,7 +2,7 @@ PyYAML==3.11
 pytest==2.9.2
 tox==2.3.1
 cryptography==1.4
-cookiecutter
+cookiecutter>=1.4.0
 pytest-cookies
 watchdog
 alabaster


### PR DESCRIPTION
This will advise users with old cookiecutter versions to upgrade and prevent bug reports like https://github.com/audreyr/cookiecutter-pypackage/issues/99 and https://github.com/audreyr/cookiecutter-pypackage/issues/194