### PR TITLE
Support replaying last run watching for changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,7 @@ BAKE_OPTIONS=--no-input
 help:
 	@echo "bake 	generate project using defaults"
 	@echo "watch 	generate project using defaults and watch for changes"
-	@echo
-	@echo "To replay last run, use:  make watch -e BAKE_OPTIONS=--replay"
+	@echo "replay 	replay last cookiecutter run and watch for changes"
 
 bake:
 	cookiecutter $(BAKE_OPTIONS) . --overwrite-if-exists
@@ -12,6 +11,6 @@ bake:
 watch: bake
 	watchmedo shell-command -p '*.*' -c 'make bake -e BAKE_OPTIONS=$(BAKE_OPTIONS)' -W -R -D \{{cookiecutter.project_slug}}/
 
-watch-replay: BAKE_OPTIONS=--replay
-watch-replay: watch
+replay: BAKE_OPTIONS=--replay
+replay: watch
 	;

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,17 @@
+BAKE_OPTIONS=--no-input
+
 help:
 	@echo "bake 	generate project using defaults"
 	@echo "watch 	generate project using defaults and watch for changes"
+	@echo
+	@echo "To replay last run, use:  make watch -e BAKE_OPTIONS=--replay"
 
 bake:
-	cookiecutter --no-input . --overwrite-if-exists
+	cookiecutter $(BAKE_OPTIONS) . --overwrite-if-exists
 
 watch: bake
-	watchmedo shell-command -p '*.*' -c 'make bake' -W -R -D \{{cookiecutter.project_slug}}/
+	watchmedo shell-command -p '*.*' -c 'make bake -e BAKE_OPTIONS=$(BAKE_OPTIONS)' -W -R -D \{{cookiecutter.project_slug}}/
+
+watch-replay: BAKE_OPTIONS=--replay
+watch-replay: watch
+	;


### PR DESCRIPTION
This is a follow-up to https://github.com/audreyr/cookiecutter-pypackage/pull/170, mainly adding support for running replays.

Having this, if you want to keep baking a project using a specific set of arguments, you can:

* run it once with `cookiecutter .`, answer the prompt with the desired values
* then, run `make replay` to keep rebaking it.

You can also pass arbitrary options to cookiecutter through the `BAKE_OPTIONS` variable, e.g.: `make watch -e BAKE_OPTIONS=--replay -o other_output_dir`.

Does this look good?