### PR TITLE
Add msys to PATH in appveyor, in order to run make (fixes #208)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ environment:
       TOX_ENV: "py35"
 
 init:
-  - set PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%
+  - set PATH=%PYTHON%;%PYTHON%\Scripts;C:\MinGW\msys\1.0\bin;%PATH%
   - "git config --system http.sslcainfo \"C:\\Program Files\\Git\\mingw64\\ssl\\certs\\ca-bundle.crt\""
   - "%PYTHON%/python -V"
   - "%PYTHON%/python -c \"import struct;print(8 * struct.calcsize(\'P\'))\""

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,7 +36,7 @@ init:
 install:
   - "%PYTHON%/Scripts/easy_install -U pip"
   - "%PYTHON%/Scripts/pip install tox"
-  - "%PYTHON%/Scripts/pip install wheel"
+  - "%PYTHON%/python -m pip install -U wheel"
 
 build: false  # Not a C# project, build stuff at the test step instead.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,7 +36,7 @@ init:
 install:
   - "%PYTHON%/Scripts/easy_install -U pip"
   - "%PYTHON%/Scripts/pip install tox"
-  - "%PYTHON%/python -m pip install -U wheel"
+  - "%PYTHON%/python -m pip install -U wheel setuptools"
 
 build: false  # Not a C# project, build stuff at the test step instead.
 


### PR DESCRIPTION
This is an attempt to fix the AppVeyor build, as per answer here:
https://twitter.com/appveyor/status/502543860040335360

This of course doesn't eliminate the problem of relying on Make, perhaps one more reason for #172 .

Let's see if the build turn green.