### PR TITLE
issue208-get-windows-builds-working

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ environment:
       TOX_ENV: "py35"
 
 init:
-  - set PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%
+  - set PATH=%PYTHON%;%PYTHON%\Scripts;C:\MinGW\msys\1.0\bin;%PATH%
   - "git config --system http.sslcainfo \"C:\\Program Files\\Git\\mingw64\\ssl\\certs\\ca-bundle.crt\""
   - "%PYTHON%/python -V"
   - "%PYTHON%/python -c \"import struct;print(8 * struct.calcsize(\'P\'))\""
@@ -44,7 +44,7 @@ test_script:
   - "%PYTHON%/Scripts/tox -e %TOX_ENV%"
 
 after_test:
-  - "%PYTHON%/python setup.py bdist_wheel"
+  - "%PYTHON%/python setup.py bdist"
   - ps: "ls dist"
 
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,7 +44,7 @@ test_script:
   - "%PYTHON%/Scripts/tox -e %TOX_ENV%"
 
 after_test:
-  - "%PYTHON%/python setup.py bdist"
+  - "%PYTHON%/python setup.py --command-packages wheel bdist_wheel"
   - ps: "ls dist"
 
 artifacts:

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -11,20 +11,17 @@ webbrowser.open("file://" + pathname2url(os.path.abspath(sys.argv[1])))
 endef
 export BROWSER_PYSCRIPT
 
-define PRINT_HELP_PYSCRIPT
-import re, sys
-
-for line in sys.stdin:
-	match = re.match(r'^([a-zA-Z_-]+):.*?## (.*)$$', line)
-	if match:
-		target, help = match.groups()
-		print("%-20s %s" % (target, help))
-endef
-export PRINT_HELP_PYSCRIPT
 BROWSER := python -c "$$BROWSER_PYSCRIPT"
 
 help:
-	@python -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
+	echo "import re, sys" > .print_help_script.py
+	echo "for line in sys.stdin:" >> .print_help_script.py
+	echo "    match = re.match(r'^([a-zA-Z_-]+):.*?## (.*)$$', line)" >> .print_help_script.py
+	echo "    if match:" >> .print_help_script.py
+	echo "        target, help = match.groups()" >> .print_help_script.py
+	echo "        print('%-20s %s' % (target, help))" >> .print_help_script.py
+	@python .print_help_script.py < $(MAKEFILE_LIST)
+	rm -f .print_help_script.py
 
 clean: clean-build clean-pyc clean-test ## remove all build, test, coverage and Python artifacts
 

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -11,17 +11,20 @@ webbrowser.open("file://" + pathname2url(os.path.abspath(sys.argv[1])))
 endef
 export BROWSER_PYSCRIPT
 
+define PRINT_HELP_PYSCRIPT
+import re, sys
+
+for line in sys.stdin:
+	match = re.match(r'^([a-zA-Z_-]+):.*?## (.*)$$', line)
+	if match:
+		target, help = match.groups()
+		print("%-20s %s" % (target, help))
+endef
+export PRINT_HELP_PYSCRIPT
 BROWSER := python -c "$$BROWSER_PYSCRIPT"
 
 help:
-	echo "import re, sys" > .print_help_script.py
-	echo "for line in sys.stdin:" >> .print_help_script.py
-	echo "    match = re.match(r'^([a-zA-Z_-]+):.*?## (.*)$$', line)" >> .print_help_script.py
-	echo "    if match:" >> .print_help_script.py
-	echo "        target, help = match.groups()" >> .print_help_script.py
-	echo "        print('%-20s %s' % (target, help))" >> .print_help_script.py
-	@python .print_help_script.py < $(MAKEFILE_LIST)
-	rm -f .print_help_script.py
+	@python -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
 
 clean: clean-build clean-pyc clean-test ## remove all build, test, coverage and Python artifacts
 


### PR DESCRIPTION
appveyor.yml
    - include msys\bin to provide make
    - no command for bdist_wheel when running python setup.py so replace with bdist
Makefile
    - windows would not allow the complex python -c commands so replaced with a temp script.

Testing - Already had failed tests that are passing now. No new tests seemed to be required.