### PR TITLE
Do not parameterize license text (fixes #227)

### DIFF
--- a/{{cookiecutter.project_slug}}/LICENSE
+++ b/{{cookiecutter.project_slug}}/LICENSE
@@ -24,7 +24,7 @@ are permitted provided that the following conditions are met:
   list of conditions and the following disclaimer in the documentation and/or
   other materials provided with the distribution.
 
-* Neither the name of {{ cookiecutter.project_name }} nor the names of its
+* Neither the name of the copyright holder nor the names of its
   contributors may be used to endorse or promote products derived from this
   software without specific prior written permission.
 


### PR DESCRIPTION
Avoid parameterizing BSD license text by using revised version (text from: http://spdx.org/licenses/BSD-3-Clause.html).

This is better for users too, no need to update the license text in case they decide to change the project name.