### PR TITLE
[wheel] -> [bdist_wheel]

### DIFF
--- a/{{cookiecutter.project_slug}}/setup.cfg
+++ b/{{cookiecutter.project_slug}}/setup.cfg
@@ -11,7 +11,7 @@ replace = version='{new_version}'
 search = __version__ = '{current_version}'
 replace = __version__ = '{new_version}'
 
-[wheel]
+[bdist_wheel]
 universal = 1
 
 [flake8]


### PR DESCRIPTION
`[wheel]` is legacy and doesn't support all the options. See the [bdist_wheel source](https://bitbucket.org/pypa/wheel/src/cf4e2d98ecb1f168c50a6de496959b4a10c6b122/wheel/bdist_wheel.py?at=default&fileviewer=file-view-default#bdist_wheel.py-119).