### PR TITLE
More sane place for adding requirements.txt 2 tox.ini

### DIFF
--- a/{{cookiecutter.project_slug}}/tox.ini
+++ b/{{cookiecutter.project_slug}}/tox.ini
@@ -12,6 +12,9 @@ setenv =
 {% if cookiecutter.use_pytest == 'y' -%}
 deps =
     -r{toxinidir}/requirements_dev.txt
+; If you want to make tox run the tests with the same versions, create a
+; requirements.txt with the pinned versions and uncomment the following line:
+;     -r{toxinidir}/requirements.txt
 commands =
     pip install -U pip
     py.test --basetemp={envtmpdir}
@@ -19,7 +22,3 @@ commands =
 commands = python setup.py test
 {%- endif %}
 
-; If you want to make tox run the tests with the same versions, create a
-; requirements.txt with the pinned versions and uncomment the following lines:
-; deps =
-;     -r{toxinidir}/requirements.txt


### PR DESCRIPTION
Hi Audrey,
Literally doing what the comment says in tox.ini would break it:
py._iniconfig.ParseError: cookiecutter-pypackage/tox.ini:19: duplicate name 'deps'
Moving the comment would fix it.
Groet,
Maarten
