### PR TITLE
Update GPL license classifier

### DIFF
--- a/{{cookiecutter.project_slug}}/setup.py
+++ b/{{cookiecutter.project_slug}}/setup.py
@@ -25,7 +25,7 @@ test_requirements = [
     'BSD license': 'License :: OSI Approved :: BSD License',
     'ISC license': 'License :: OSI Approved :: ISC License (ISCL)',
     'Apache Software License 2.0': 'License :: OSI Approved :: Apache Software License',
-    'GNU General Public License v3': 'License :: OSI Approved :: GNU General Public License'
+    'GNU General Public License v3': 'License :: OSI Approved :: GNU General Public License v3 (GPLv3)'
 } %}
 
 setup(


### PR DESCRIPTION
According to https://pypi.python.org/pypi?%3Aaction=list_classifiers the name for GPL license classifier is incomplete and pypi will not accept the package.