### PR TITLE
recursive include all files of "project_slug" module

### DIFF
--- a/{{cookiecutter.project_slug}}/MANIFEST.in
+++ b/{{cookiecutter.project_slug}}/MANIFEST.in
@@ -1,3 +1,4 @@
+graft {{ cookiecutter.project_slug }}
 {% if cookiecutter.create_author_file == 'y' %}
 include AUTHORS.rst
 {% endif %}


### PR DESCRIPTION
if I include python submodules, and other folders inside [package](https://github.com/audreyr/cookiecutter-pypackage/tree/master/%7B%7Bcookiecutter.project_slug%7D%7D/%7B%7Bcookiecutter.project_slug%7D%7D), the current configuration not include them in sdist and wheel package.

this pull-request resolves this (at least resolved to me).

I saw django doing the same:
https://github.com/django/django/blob/master/MANIFEST.in#L9
