### PR TITLE
Removed unittest style from pytest tests and removed if __name__ == _…

### DIFF
--- a/{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py
+++ b/{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py
@@ -26,30 +26,26 @@ from {{ cookiecutter.project_slug }} import cli
 
 
 {% if cookiecutter.use_pytest == 'y' -%}
-class Test{{ cookiecutter.project_slug|title }}(object):
+@pytest.fixture
+def some_fixture():
+    pass
 
-    @classmethod
-    def setup_class(cls):
-        pass
 
-    def test_something(self):
-        pass
+def test_something(some_fixture):
+    pass
+
 
 {%- if cookiecutter.command_line_interface|lower == 'click' %}
-    def test_command_line_interface(self):
-        runner = CliRunner()
-        result = runner.invoke(cli.main)
-        assert result.exit_code == 0
-        assert '{{ cookiecutter.project_slug }}.cli.main' in result.output
-        help_result = runner.invoke(cli.main, ['--help'])
-        assert help_result.exit_code == 0
-        assert '--help  Show this message and exit.' in help_result.output
+def test_command_line_interface(self):
+    runner = CliRunner()
+    result = runner.invoke(cli.main)
+    assert result.exit_code == 0
+    assert '{{ cookiecutter.project_slug }}.cli.main' in result.output
+    help_result = runner.invoke(cli.main, ['--help'])
+    assert help_result.exit_code == 0
+    assert '--help  Show this message and exit.' in help_result.output
 
 {%- endif %}
-
-    @classmethod
-    def teardown_class(cls):
-        pass
 {% else %}
 class Test{{ cookiecutter.project_slug|title }}(unittest.TestCase):
 
@@ -72,8 +68,4 @@ class Test{{ cookiecutter.project_slug|title }}(unittest.TestCase):
         assert '--help  Show this message and exit.' in help_result.output
 
 {%- endif %}
-
-
-if __name__ == '__main__':
-    sys.exit(unittest.main())
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py
+++ b/{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py
@@ -27,16 +27,24 @@ from {{ cookiecutter.project_slug }} import cli
 
 {% if cookiecutter.use_pytest == 'y' -%}
 @pytest.fixture
-def some_fixture():
+def response():
+    """Sample pytest fixture.
+    See more at: http://doc.pytest.org/en/latest/fixture.html
+    """
+    # import requests
+    # return requests.get('https://github.com/audreyr/cookiecutter-pypackage')
     pass
 
 
-def test_something(some_fixture):
+def test_response(response):
+    """Sample pytest test function with the pytest fixture as an argument.
+    """
+    # assert response.status_code == 200
     pass
 
 
 {%- if cookiecutter.command_line_interface|lower == 'click' %}
-def test_command_line_interface(self):
+def test_command_line_interface():
     runner = CliRunner()
     result = runner.invoke(cli.main)
     assert result.exit_code == 0

--- a/{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py
+++ b/{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py
@@ -33,14 +33,13 @@ def response():
     """
     # import requests
     # return requests.get('https://github.com/audreyr/cookiecutter-pypackage')
-    pass
 
 
-def test_response(response):
+def test_content(response):
     """Sample pytest test function with the pytest fixture as an argument.
     """
-    # assert response.status_code == 200
-    pass
+    # from bs4 import BeautifulSoup
+    # assert 'GitHub' in BeautifulSoup(r.content).title.string
 
 
 {%- if cookiecutter.command_line_interface|lower == 'click' %}


### PR DESCRIPTION
In reference to #254 I changed the style of the pytest tests to be more inline with the typical pytest convention. I added a pytest fixture and a test function that uses the fixture as an argument. I also removed the if dunder name == dunder main from the unittest tests. With the tests directory listed in the test_suite keyword argument of setup() in setup.py, 'python setup.py test' will discover the tests automatically without the need for the dunder statement.