### PR TITLE
Account for author names with apostrophes

### DIFF
--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -101,6 +101,13 @@ def test_bake_withspecialchars_and_run_tests(cookies):
         run_inside_dir('python setup.py test', str(result.project)) == 0
 
 
+def test_bake_with_apostrophe_and_run_tests(cookies):
+    """Ensure that a `full_name` with apostrophes does not break setup.py"""
+    with bake_in_temp_dir(cookies, extra_context={'full_name': "O'connor"}) as result:
+        assert result.project.isdir()
+        run_inside_dir('python setup.py test', str(result.project)) == 0
+
+
 def test_bake_and_run_travis_pypi_setup(cookies):
     # given:
     with bake_in_temp_dir(cookies) as result:

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/__init__.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
 
-__author__ = '{{ cookiecutter.full_name }}'
+__author__ = """{{ cookiecutter.full_name }}"""
 __email__ = '{{ cookiecutter.email }}'
 __version__ = '{{ cookiecutter.version }}'


### PR DESCRIPTION
This fixes cases where the author name in `__init__.py` may cause a SyntaxError when the author name contains quotes.
e.g. for my name `Kevin Ndung'u` or other common names such as `O'Connor`