### PR TITLE
Remove auto-generated comment :)

### DIFF
--- a/{{cookiecutter.project_slug}}/docs/index.rst
+++ b/{{cookiecutter.project_slug}}/docs/index.rst
@@ -1,8 +1,3 @@
-.. {{ cookiecutter.project_slug }} documentation master file, created by
-   sphinx-quickstart on Tue Jul  9 22:26:36 2013.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
 Welcome to {{ cookiecutter.project_name }}'s documentation!
 ======================================
 


### PR DESCRIPTION
I guess the generated docs files are quite modified compared to what sphinx autogenerates, so we can remove this :)