### PR TITLE
Invoke py.test correctly with coverage run

### DIFF
--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -62,7 +62,7 @@ test-all: ## run tests on every Python version with tox
 
 coverage: ## check code coverage quickly with the default Python
 	{% if cookiecutter.use_pytest == 'y' -%}
-		coverage run --source {{ cookiecutter.project_slug }} py.test
+		coverage run --source {{ cookiecutter.project_slug }} -m pytest
 	{% else %}
 		coverage run --source {{ cookiecutter.project_slug }} setup.py test
 	{% endif %}


### PR DESCRIPTION
If I run `make coverage` (Python 3.5), I get:

``` 
$> make coverage 
coverage run --source my_project py.test
No file to run: 'py.test'
Makefile:64: recipe for target 'coverage' failed
make: *** [coverage] Error 1
```

Correct invocation is to use the -m switch.

http://stackoverflow.com/a/16524426/405682