### PR TITLE
the tests directory should not contain __init__.py

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -16,6 +16,9 @@ if __name__ == '__main__':
         remove_file('AUTHORS.rst')
         remove_file('docs/authors.rst')
 
+    if '{{ cookiecutter.use_pytest }}' == 'y':
+        remove_file('tests/__init__.py')
+
     if 'no' in '{{ cookiecutter.command_line_interface|lower }}':
         cli_file = os.path.join('{{ cookiecutter.project_slug }}', 'cli.py')
         remove_file(cli_file)


### PR DESCRIPTION
[pytest recommends this:]( http://doc.pytest.org/en/latest/goodpractices.html)

> 
>  avoid “__init__.py” files in your test directories. This way your tests
>  can run easily against an installed version of mypkg, independently
>  from the installed package if it contains the tests or not.
> 


 Let's make Python projects smarter