### PR TITLE
Trim MANIFEST.in's blank lines

### DIFF
--- a/{{cookiecutter.project_slug}}/MANIFEST.in
+++ b/{{cookiecutter.project_slug}}/MANIFEST.in
@@ -1,6 +1,6 @@
-{% if cookiecutter.create_author_file == 'y' %}
+{% if cookiecutter.create_author_file == 'y' -%}
 include AUTHORS.rst
-{% endif %}
+{% endif -%}
 include CONTRIBUTING.rst
 include HISTORY.rst
 include LICENSE


### PR DESCRIPTION
Use jinja's whitespace trimming to delete blank lines around `AUTHORS.rst` in `MANIFEST.in`.