### PR TITLE
Change the way TravisCI is used.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,4 @@ target/
 # Cookiecutter
 output/
 python_boilerplate/
+\#*\#

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,17 @@
 language: python
 
-python: 3.5
-env:
-  - TOXENV=py27
-  - TOXENV=py33
-  - TOXENV=py34
-  - TOXENV=py35
+python: 
+  - 2.7
+  - 3.3
+  - 3.4
+  - 3.5
+  - 3.6
 
 install:
   - pip install -U tox
 
 script:
-  - tox
+  - tox -e ${TRAVIS_PYTHON_VERSION//./}
 
 deploy:
   provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,11 @@ python:
 
 install:
   - pip install -U tox
+  - export TOXENV=${TRAVIS_PYTHON_VERSION}
+  # Add "py" prefix and remove the dot
+  - if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then export TOXENV=py${TRAVIS_PYTHON_VERSION//./}; fi
 
-script:
-  - tox -e ${TRAVIS_PYTHON_VERSION//./}
+script: tox
 
 deploy:
   provider: pypi

--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,24 @@ watch: bake
 replay: BAKE_OPTIONS=--replay
 replay: watch
 	;
+
+clean: clean-build clean-pyc clean-test ## remove all build, test, coverage and Python artifacts
+
+
+clean-build: ## remove build artifacts
+	rm -fr build/
+	rm -fr dist/
+	rm -fr .eggs/
+	find . -name '*.egg-info' -exec rm -fr {} +
+	find . -name '*.egg' -exec rm -f {} +
+
+clean-pyc: ## remove Python file artifacts
+	find . -name '*.pyc' -exec rm -f {} +
+	find . -name '*.pyo' -exec rm -f {} +
+	find . -name '*~' -exec rm -f {} +
+	find . -name '__pycache__' -exec rm -fr {} +
+
+clean-test: ## remove test and coverage artifacts
+	rm -fr .tox/
+	rm -f .coverage
+	rm -fr htmlcov/

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,7 @@
 PyYAML==3.11
 pytest==2.9.2
 tox==2.3.1
-cryptography==1.7
+cryptography==1.8.1
 cookiecutter>=1.4.0
 pytest-cookies==0.2.0
 watchdog==0.8.3

--- a/{{cookiecutter.project_slug}}/.travis.yml
+++ b/{{cookiecutter.project_slug}}/.travis.yml
@@ -12,10 +12,14 @@ python:
   - pypy
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
-install: pip install -U tox
+install:
+  - pip install -U tox
+  - export TOXENV=${TRAVIS_PYTHON_VERSION}
+  # Add "py" prefix and remove the dot
+  - if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then export TOXENV=py${TRAVIS_PYTHON_VERSION//./}; fi
 
 # command to run tests, e.g. python setup.py test
-script: tox -e ${TRAVIS_PYTHON_VERSION//./}
+script: tox
 
 {% if cookiecutter.use_pypi_deployment_with_travis == 'y' -%}
 # After you create the Github repo and add it to Travis, run the

--- a/{{cookiecutter.project_slug}}/.travis.yml
+++ b/{{cookiecutter.project_slug}}/.travis.yml
@@ -2,21 +2,20 @@
 # This file will be regenerated if you run travis_pypi_setup.py
 
 language: python
-python: 3.5
-
-env:
-  - TOXENV=py35
-  - TOXENV=py34
-  - TOXENV=py33
-  - TOXENV=py27
-  - TOXENV=py26
-  - TOXENV=pypy
+python:
+  - 2.6
+  - 2.7
+  - 3.3
+  - 3.4
+  - 3.5
+  - 3.6
+  - pypy
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: pip install -U tox
 
 # command to run tests, e.g. python setup.py test
-script: tox -e ${TOXENV}
+script: tox -e ${TRAVIS_PYTHON_VERSION//./}
 
 {% if cookiecutter.use_pypi_deployment_with_travis == 'y' -%}
 # After you create the Github repo and add it to Travis, run the

--- a/{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py
+++ b/{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py
@@ -65,6 +65,7 @@ class Test{{ cookiecutter.project_slug|title }}(unittest.TestCase):
     def test_000_something(self):
         pass
 {% if cookiecutter.command_line_interface|lower == 'click' %}
+
     def test_command_line_interface(self):
         runner = CliRunner()
         result = runner.invoke(cli.main)
@@ -73,6 +74,5 @@ class Test{{ cookiecutter.project_slug|title }}(unittest.TestCase):
         help_result = runner.invoke(cli.main, ['--help'])
         assert help_result.exit_code == 0
         assert '--help  Show this message and exit.' in help_result.output
-
 {%- endif %}
 {%- endif %}


### PR DESCRIPTION
Instead of using single python version for all builds on Travis and then using tox to setup different interpreters in different environments, setup TravisCI integration in a way such, that it uses its own mechanisms to handle Python installation and then runs tox with only a single environment (single python version) inside the build.

This way you won’t get errors about missing Python interpreter from TravisCI, that you had chances to get in the previous configuration.