### PR TITLE
Support hyphens in project name. Fixes #250

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -3,7 +3,7 @@
   "email": "aroy@alum.mit.edu",
   "github_username": "audreyr",
   "project_name": "Python Boilerplate",
-  "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '_') }}",
+  "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}",
   "project_short_description": "Python Boilerplate contains all the boilerplate you need to create a Python package.",
   "pypi_username": "{{ cookiecutter.github_username }}",
   "version": "0.1.0",

--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -195,10 +195,9 @@ def test_not_using_pytest(cookies):
         assert "import pytest" not in ''.join(lines)
 
 
-def test_project_with_invalid_module_name(cookies):
+def test_project_with_hyphen_in_module_name(cookies):
     result = cookies.bake(extra_context={'project_name': 'something-with-a-dash'})
-    assert result.project is None
-    result = cookies.bake()
+    assert result.project is not None
     project_path = str(result.project)
 
     # when:


### PR DESCRIPTION
Hyphens in project names were considered invalid as per the existing test.

It should be possible to support them by replacing hyphens by underscores when generating the default slug, as suggested in #250. 