### PR TITLE
Fix include of authors

### DIFF
--- a/{{cookiecutter.project_slug}}/docs/index.rst
+++ b/{{cookiecutter.project_slug}}/docs/index.rst
@@ -10,8 +10,8 @@ Contents:
    installation
    usage
    contributing
-   {% if cookiecutter.create_author_file == 'y' -%}authors{% endif -%}
-   history
+   {% if cookiecutter.create_author_file == 'y' -%}authors
+   {% endif -%}history
 
 Indices and tables
 ==================


### PR DESCRIPTION
Hi,

Thanks for cookiecutter and this cool template!

I noticed a small bug: with `create_author_file=y`,`docs/index.rst` renders as

```
   ...
   installation
   usage
   contributing
   authorshistory
```
 
I had a quick look at `http://jinja.pocoo.org/docs/2.9/templates/#whitespace-control` but I couldn't figure out the 'right' way to fix it. So I did it the dumb way ;)

Edit: this was changed in the last commit https://github.com/audreyr/cookiecutter-pypackage/commit/af795bba4ae7fcabb4d117df01b07ba41b1d683d