### PR TITLE
Keep trailing whitespace in diff files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,3 +19,6 @@ insert_final_newline = false
 
 [Makefile]
 indent_style = tab
+
+[*.{diff,patch}]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Without this, editorconfig-vim strips trailing whitespace in context and
old lines in unified diff (used frequently in the git add --patch
workflow), upon saving; the resulting diff fails to apply.