### PR TITLE
Use Tox-Travis for environment selection

### DIFF
--- a/{{cookiecutter.project_slug}}/.travis.yml
+++ b/{{cookiecutter.project_slug}}/.travis.yml
@@ -2,21 +2,18 @@
 # This file will be regenerated if you run travis_pypi_setup.py
 
 language: python
-python: 3.5
-
-env:
-  - TOXENV=py35
-  - TOXENV=py34
-  - TOXENV=py33
-  - TOXENV=py27
-  - TOXENV=py26
-  - TOXENV=pypy
+python:
+  - 3.5
+  - 3.4
+  - 3.3
+  - 2.7
+  - 2.6
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
-install: pip install -U tox
+install: pip install -U tox-travis
 
 # command to run tests, e.g. python setup.py test
-script: tox -e ${TOXENV}
+script: tox
 
 {% if cookiecutter.use_pypi_deployment_with_travis == 'y' -%}
 # After you create the Github repo and add it to Travis, run the
@@ -30,5 +27,5 @@ deploy:
   on:
     tags: true
     repo: {{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}
-    condition: $TOXENV == py27
+    python: 2.7
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/tox.ini
+++ b/{{cookiecutter.project_slug}}/tox.ini
@@ -1,6 +1,14 @@
 [tox]
 envlist = py26, py27, py33, py34, py35, flake8
 
+[travis]
+python =
+    3.5: py35
+    3.4: py34
+    3.3: py33
+    2.7: py27
+    2.6: py26
+
 [testenv:flake8]
 basepython=python
 deps=flake8


### PR DESCRIPTION
Tox-Travis supports mapping each Travis factor (a value of os, language,
python, environment variables, etc.) onto zero or more Tox environment
name factors, so as to fully take advantage of generative listing of
environments in Tox 1.8+.  It eases testing with a matrix of dependency
version combinations.

Examples are in https://tox-travis.readthedocs.io/en/stable/toxenv.html