### PR TITLE
Link auto-generated API into documentation index

### DIFF
--- a/{{cookiecutter.project_slug}}/docs/.gitignore
+++ b/{{cookiecutter.project_slug}}/docs/.gitignore
@@ -1,0 +1,3 @@
+/{{ cookiecutter.project_slug }}.rst
+/{{ cookiecutter.project_slug }}.*.rst
+/modules.rst

--- a/{{cookiecutter.project_slug}}/docs/index.rst
+++ b/{{cookiecutter.project_slug}}/docs/index.rst
@@ -9,6 +9,7 @@ Contents:
    readme
    installation
    usage
+   modules
    contributing
    {% if cookiecutter.create_author_file == 'y' -%}authors
    {% endif -%}history


### PR DESCRIPTION
Also .gitignore source ReST files generated by sphinx-apidoc.