### PR TITLE
Remove package directory from PYTHONPATH

### DIFF
--- a/{{cookiecutter.project_slug}}/tox.ini
+++ b/{{cookiecutter.project_slug}}/tox.ini
@@ -8,7 +8,7 @@ commands=flake8 {{ cookiecutter.project_slug }}
 
 [testenv]
 setenv =
-    PYTHONPATH = {toxinidir}:{toxinidir}/{{ cookiecutter.project_slug }}
+    PYTHONPATH = {toxinidir}
 {% if cookiecutter.use_pytest == 'y' -%}
 deps =
     -r{toxinidir}/requirements_dev.txt


### PR DESCRIPTION
Without this, if we had <project_slug>/xyz.py, it would be importable
both as "<project_slug>.xyz" (correct) and as "xyz" (incorrect).