### PR TITLE
Fixing bug with authors and history headings running together in the docs

### DIFF
--- a/{{cookiecutter.project_slug}}/docs/index.rst
+++ b/{{cookiecutter.project_slug}}/docs/index.rst
@@ -12,7 +12,8 @@ Contents:
    modules
    contributing
    {% if cookiecutter.create_author_file == 'y' -%}authors
-   {% endif -%}history
+   {% endif -%}
+   history
 
 Indices and tables
 ==================


### PR DESCRIPTION
When using both an authors and history files, the entries for both of these files in the docs run together. It looks like:
`authorshistory`
rather than:
```
authors
history
```

This PR fixes the problem.