### PR TITLE
Fix dependency installation with openssl-1.1.0f

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,7 @@
 PyYAML==3.11
 pytest==3.1.2
 tox==2.3.1
-cryptography==1.7
+cryptography==1.9
 cookiecutter>=1.4.0
 pytest-cookies==0.2.0
 watchdog==0.8.3


### PR DESCRIPTION
`cryptography==1.7` dependency fails to compile the wheel when linked
against `openssl-1.1.0f`.

Running unit tests with `tox` fails with the following error:

```
    In file included from /usr/include/openssl/cms.h:16:0,
                     from build/temp.linux-x86_64-2.7/_openssl.c:485:
    /usr/include/openssl/x509.h:552:6: note: expected ‘const X509_ALGOR ** {aka const struct X509_algor_st **}’ but argument is of type ‘X509_ALGOR ** {aka struct X509_algor_st **}’
     void X509_get0_signature(const ASN1_BIT_STRING **psig,
          ^~~~~~~~~~~~~~~~~~~
    error: command 'cc' failed with exit status 1
    
    ----------------------------------------
Command "/home/zoresvit/devel/src/temp/.tox/pypy/bin/pypy -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-XlLl5D/cryptography/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-uZTFGU-record/install-record.txt --single-version-externally-managed --compile --install-headers /home/zoresvit/devel/src/temp/.tox/pypy/include/site/python2.7/cryptography" failed with error code 1 in /tmp/pip-build-XlLl5D/cryptography/

ERROR: could not install deps [-rrequirements_dev.txt]; v = InvocationError('/home/zoresvit/devel/src/temp/.tox/pypy/bin/pip install -rrequirements_dev.txt (see /home/zoresvit/devel/src/temp/.tox/pypy/log/pypy-1.log)', 1)
d
```

The issue has been fixed in
`cryptography==1.9`:
https://github.com/pyca/cryptography/issues/3605