### PR TITLE
reminder to maintainers on how to upgrade & deploy

### DIFF
--- a/{{cookiecutter.project_slug}}/CONTRIBUTING.rst
+++ b/{{cookiecutter.project_slug}}/CONTRIBUTING.rst
@@ -115,3 +115,16 @@ To run a subset of tests::
 {% else %}
     $ python -m unittest tests.test_{{ cookiecutter.project_slug }}
 {%- endif %}
+
+Deploying
+---------
+
+A reminder for the maintainers on how to deploy.
+Make sure all your changes are committed (including an entry in HISTORY.rst).
+Then run::
+
+$ bumpversion patch # possible: major / minor / patch
+$ git push
+$ git push --tags
+
+Travis will then deploy to PyPI if tests pass.


### PR DESCRIPTION
Would a reminder like this be acceptable? I found that I often forget how to use `bumpversion`, if I need to commit things myself or not etc., so having a cheat sheet somewhere would be useful.