### PR TITLE
Fix failing Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ python:
   - 3.4
   - 3.3
   - 2.7
-  - 2.6
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: pip install -U tox-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@
 
 language: python
 python:
+  - 3.6
   - 3.5
   - 3.4
   - 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: python
 python:
   - 3.5
   - 3.4
-  - 3.3
   - 2.7
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,29 @@
+# Config file for automatic testing at travis-ci.org
+# This file will be regenerated if you run travis_pypi_setup.py
+
 language: python
+python:
+  - 3.5
+  - 3.4
+  - 3.3
+  - 2.7
+  - 2.6
 
-python: 3.5
-env:
-  - TOXENV=py27
-  - TOXENV=py33
-  - TOXENV=py34
-  - TOXENV=py35
+# command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
+install: pip install -U tox-travis
 
-install:
-  - pip install -U tox
+# command to run tests, e.g. python setup.py test
+script: tox
 
-script:
-  - tox
-
+# After you create the Github repo and add it to Travis, run the
+# travis_pypi_setup.py script to finish PyPI deployment setup
 deploy:
   provider: pypi
-  distributions: sdist
+  distributions: sdist bdist_wheel
   user: audreyr
   password:
     secure: PLEASE_REPLACE_ME
   on:
     tags: true
     repo: audreyr/python_boilerplate
-    condition: $TOXENV == py27
+    python: 2.7

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -112,7 +112,7 @@ you already have `virtualenv` and `Git` installed and ready to go.
    .. note::
       If you are missing flake8, pytest and/or tox, just pip install them into your virtualenv.
 
-8. If your contribution is a bug fix or new feature, you may want to add a test to the existing test suite. See section Add a New Test below for details. 
+8. If your contribution is a bug fix or new feature, you may want to add a test to the existing test suite. See section Add a New Test below for details.
 
 9. Commit your changes and push your branch to GitHub::
 
@@ -135,20 +135,20 @@ Before you submit a pull request, check that it meets these guidelines:
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
 
-3. The pull request should work for Python 2.6, 2.7, 3.3, 3.4 and 3.5, and for PyPy. Check
+3. The pull request should work for Python 2.7, 3.3, 3.4 and 3.5, and for PyPy. Check
    https://travis-ci.org/audreyr/cookiecutter-pypackage/pull_requests
    and make sure that the tests pass for all supported Python versions.
 
 Add a New Test
 ---------------
-When fixing a bug or adding features, it's good practice to add a test to demonstrate your fix or new feature behaves as expected. These tests should focus on one tiny bit of functionality and prove changes are correct. 
+When fixing a bug or adding features, it's good practice to add a test to demonstrate your fix or new feature behaves as expected. These tests should focus on one tiny bit of functionality and prove changes are correct.
 
 To write and run your new test, follow these steps:
 
-1. Add the new test to `tests/test_bake_project.py`. Focus your test on the specific bug or a small part of the new feature. 
+1. Add the new test to `tests/test_bake_project.py`. Focus your test on the specific bug or a small part of the new feature.
 
 2. If you have already made changes to the code, stash your changes and confirm all your changes were stashed::
-  
+
     $ git stash
     $ git stash list
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -135,7 +135,7 @@ Before you submit a pull request, check that it meets these guidelines:
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
 
-3. The pull request should work for Python 2.7, 3.4 and 3.5, and for PyPy. Check
+3. The pull request should work for Python 2.7, 3.4, 3.5 and 3.6, and for PyPy. Check
    https://travis-ci.org/audreyr/cookiecutter-pypackage/pull_requests
    and make sure that the tests pass for all supported Python versions.
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -135,7 +135,7 @@ Before you submit a pull request, check that it meets these guidelines:
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
 
-3. The pull request should work for Python 2.7, 3.3, 3.4 and 3.5, and for PyPy. Check
+3. The pull request should work for Python 2.7, 3.4 and 3.5, and for PyPy. Check
    https://travis-ci.org/audreyr/cookiecutter-pypackage/pull_requests
    and make sure that the tests pass for all supported Python versions.
 

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Features
 
 * Testing setup with ``unittest`` and ``python setup.py test`` or ``py.test``
 * Travis-CI_: Ready for Travis Continuous Integration testing
-* Tox_ testing: Setup to easily test for Python 2.6, 2.7, 3.3, 3.4, 3.5
+* Tox_ testing: Setup to easily test for Python 2.7, 3.3, 3.4, 3.5
 * Sphinx_ docs: Documentation ready for generation with, for example, ReadTheDocs_
 * Bumpversion_: Pre-configured version bumping with a single command
 * Auto-release to PyPI_ when you push a new tag to master (optional)

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Features
 
 * Testing setup with ``unittest`` and ``python setup.py test`` or ``py.test``
 * Travis-CI_: Ready for Travis Continuous Integration testing
-* Tox_ testing: Setup to easily test for Python 2.7, 3.3, 3.4, 3.5
+* Tox_ testing: Setup to easily test for Python 2.7, 3.4, 3.5
 * Sphinx_ docs: Documentation ready for generation with, for example, ReadTheDocs_
 * Bumpversion_: Pre-configured version bumping with a single command
 * Auto-release to PyPI_ when you push a new tag to master (optional)

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Features
 
 * Testing setup with ``unittest`` and ``python setup.py test`` or ``py.test``
 * Travis-CI_: Ready for Travis Continuous Integration testing
-* Tox_ testing: Setup to easily test for Python 2.7, 3.4, 3.5
+* Tox_ testing: Setup to easily test for Python 2.7, 3.4, 3.5, 3.6
 * Sphinx_ docs: Documentation ready for generation with, for example, ReadTheDocs_
 * Bumpversion_: Pre-configured version bumping with a single command
 * Auto-release to PyPI_ when you push a new tag to master (optional)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,12 +9,6 @@ environment:
     - PYTHON: "C:\\Python27-x64"
       TOX_ENV: "py27"
 
-    - PYTHON: "C:\\Python33"
-      TOX_ENV: "py33"
-
-    - PYTHON: "C:\\Python33-x64"
-      TOX_ENV: "py33"
-
     - PYTHON: "C:\\Python34"
       TOX_ENV: "py34"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,6 +21,12 @@ environment:
     - PYTHON: "C:\\Python35-x64"
       TOX_ENV: "py35"
 
+    - PYTHON: "C:\\Python36"
+      TOX_ENV: "py36"
+
+    - PYTHON: "C:\\Python36-x64"
+      TOX_ENV: "py36"
+
 init:
   - set PATH=%PYTHON%;%PYTHON%\Scripts;C:\MinGW\msys\1.0\bin;%PATH%
   - "git config --system http.sslcainfo \"C:\\Program Files\\Git\\mingw64\\ssl\\certs\\ca-bundle.crt\""

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,8 +1,8 @@
-PyYAML==3.11
-pytest==3.1.2
-tox==2.3.1
-cryptography==1.7
+PyYAML==3.12
+pytest==3.3.2
+tox==2.9.1
+cryptography==2.1.4
 cookiecutter>=1.4.0
-pytest-cookies==0.2.0
+pytest-cookies==0.3.0
 watchdog==0.8.3
-alabaster==0.7.8
+alabaster==0.7.10

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,14 @@
 [tox]
-envlist = py27, py33, py34, py35, pypy, docs
+envlist = py26, py27, py33, py34, py35, pypy, docs
 skipsdist = true
+
+[travis]
+python =
+    3.5: py35
+    3.4: py34
+    3.3: py33
+    2.7: py27
+    2.6: py26
 
 [testenv:docs]
 basepython=python
@@ -10,8 +18,10 @@ commands=
     sphinx-build -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
 
 [testenv]
-whitelist_externals = bash
+setenv =
+    PYTHONPATH = {toxinidir}
 deps =
-    -rrequirements_dev.txt
+    -r{toxinidir}/requirements_dev.txt
 commands =
+    pip install -U pip
     py.test

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 [tox]
-envlist = py27, py34, py35, pypy, docs
+envlist = py27, py34, py35, p36, pypy, docs
 skipsdist = true
 
 [travis]
 python =
+    3.6: py36
     3.5: py35
     3.4: py34
     2.7: py27

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 [tox]
-envlist = py27, py33, py34, py35, pypy, docs
+envlist = py27, py34, py35, pypy, docs
 skipsdist = true
 
 [travis]
 python =
     3.5: py35
     3.4: py34
-    3.3: py33
     2.7: py27
 
 [testenv:docs]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33, py34, py35, pypy, docs
+envlist = py27, py33, py34, py35, pypy, docs
 skipsdist = true
 
 [travis]
@@ -8,7 +8,6 @@ python =
     3.4: py34
     3.3: py33
     2.7: py27
-    2.6: py26
 
 [testenv:docs]
 basepython=python

--- a/{{cookiecutter.project_slug}}/.travis.yml
+++ b/{{cookiecutter.project_slug}}/.travis.yml
@@ -7,7 +7,6 @@ python:
   - 3.4
   - 3.3
   - 2.7
-  - 2.6
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: pip install -U tox-travis

--- a/{{cookiecutter.project_slug}}/.travis.yml
+++ b/{{cookiecutter.project_slug}}/.travis.yml
@@ -3,6 +3,7 @@
 
 language: python
 python:
+  - 3.6
   - 3.5
   - 3.4
   - 2.7

--- a/{{cookiecutter.project_slug}}/.travis.yml
+++ b/{{cookiecutter.project_slug}}/.travis.yml
@@ -5,7 +5,6 @@ language: python
 python:
   - 3.5
   - 3.4
-  - 3.3
   - 2.7
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors

--- a/{{cookiecutter.project_slug}}/CONTRIBUTING.rst
+++ b/{{cookiecutter.project_slug}}/CONTRIBUTING.rst
@@ -101,7 +101,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.7, 3.3, 3.4 and 3.5, and for PyPy. Check
+3. The pull request should work for Python 2.7, 3.4 and 3.5, and for PyPy. Check
    https://travis-ci.org/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}/pull_requests
    and make sure that the tests pass for all supported Python versions.
 

--- a/{{cookiecutter.project_slug}}/CONTRIBUTING.rst
+++ b/{{cookiecutter.project_slug}}/CONTRIBUTING.rst
@@ -101,7 +101,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.6, 2.7, 3.3, 3.4 and 3.5, and for PyPy. Check
+3. The pull request should work for Python 2.7, 3.3, 3.4 and 3.5, and for PyPy. Check
    https://travis-ci.org/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}/pull_requests
    and make sure that the tests pass for all supported Python versions.
 

--- a/{{cookiecutter.project_slug}}/CONTRIBUTING.rst
+++ b/{{cookiecutter.project_slug}}/CONTRIBUTING.rst
@@ -101,7 +101,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.7, 3.4 and 3.5, and for PyPy. Check
+3. The pull request should work for Python 2.7, 3.4, 3.5 and 3.6, and for PyPy. Check
    https://travis-ci.org/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}/pull_requests
    and make sure that the tests pass for all supported Python versions.
 

--- a/{{cookiecutter.project_slug}}/requirements_dev.txt
+++ b/{{cookiecutter.project_slug}}/requirements_dev.txt
@@ -1,14 +1,14 @@
-pip==8.1.2
+pip==9.0.1
 bumpversion==0.5.3
-wheel==0.29.0
+wheel==0.30.0
 watchdog==0.8.3
-flake8==2.6.0
-tox==2.3.1
-coverage==4.1
-Sphinx==1.4.8
+flake8==3.5.0
+tox==2.9.1
+coverage==4.4.2
+Sphinx==1.6.5
 {% if cookiecutter.use_pypi_deployment_with_travis == 'y' -%}
-cryptography==1.7
+cryptography==2.1.4
 PyYAML==3.11{% endif %}
 {% if cookiecutter.use_pytest == 'y' -%}
-pytest==2.9.2
+pytest==3.3.2
 pytest-runner==2.11.1{% endif %}

--- a/{{cookiecutter.project_slug}}/setup.py
+++ b/{{cookiecutter.project_slug}}/setup.py
@@ -71,7 +71,6 @@ setup(
 {%- endif %}
         'Natural Language :: English',
         "Programming Language :: Python :: 2",
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',

--- a/{{cookiecutter.project_slug}}/setup.py
+++ b/{{cookiecutter.project_slug}}/setup.py
@@ -73,7 +73,6 @@ setup(
         "Programming Language :: Python :: 2",
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
     ],

--- a/{{cookiecutter.project_slug}}/setup.py
+++ b/{{cookiecutter.project_slug}}/setup.py
@@ -75,6 +75,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
     test_suite='tests',
     tests_require=test_requirements,

--- a/{{cookiecutter.project_slug}}/tox.ini
+++ b/{{cookiecutter.project_slug}}/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33, py34, py35, flake8
+envlist = py27, py33, py34, py35, flake8
 
 [travis]
 python =
@@ -7,7 +7,6 @@ python =
     3.4: py34
     3.3: py33
     2.7: py27
-    2.6: py26
 
 [testenv:flake8]
 basepython=python

--- a/{{cookiecutter.project_slug}}/tox.ini
+++ b/{{cookiecutter.project_slug}}/tox.ini
@@ -1,8 +1,9 @@
 [tox]
-envlist = py27, py34, py35, flake8
+envlist = py27, py34, py35, py36, flake8
 
 [travis]
 python =
+    3.6: py36
     3.5: py35
     3.4: py34
     2.7: py27

--- a/{{cookiecutter.project_slug}}/tox.ini
+++ b/{{cookiecutter.project_slug}}/tox.ini
@@ -1,11 +1,10 @@
 [tox]
-envlist = py27, py33, py34, py35, flake8
+envlist = py27, py34, py35, flake8
 
 [travis]
 python =
     3.5: py35
     3.4: py34
-    3.3: py33
     2.7: py27
 
 [testenv:flake8]


### PR DESCRIPTION
The Travis build of projects generated with this cookiecutter fail out of the box. The Travis build for the project itself is also failing. This pull request attempts to resolve this by:

- Updating the test setup of the project to match the setup of the generated project. The generated project seems to have a more modern approach, and keeping this uniform will improve maintainability.
- Update all dependencies to the most recent versions.
- Remove support for Python 2.6 (no longer supported by the Python core team) and Python 3.3 (not supported by Pytest)

Additionally, support for Python 3.6 was added, since this is the most recent version.