### PR TITLE
fix release target in makefile

### DIFF
--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -83,7 +83,7 @@ docs: ## generate Sphinx HTML documentation, including API docs
 servedocs: docs ## compile the docs watching for changes
 	watchmedo shell-command -p '*.rst' -c '$(MAKE) -C docs html' -R -D .
 
-release: clean ## package and upload a release
+release: dist ## package and upload a release
 	twine upload dist/*
 
 dist: clean ## builds source and wheel package


### PR DESCRIPTION
since the `clean` target removes the `dist` folder, it doesn't make sense to make it a dependency of `make release`. on the other hand, it would make a lot of sense to let it depend on `make dist`