### PR TITLE
Improved user experience on windows

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -110,7 +110,7 @@ In your terminal, your virtualenv should still be activated. If it isn't, activa
 
 .. code-block:: bash
 
-    travis encrypt --add deploy.password
+    travis encrypt X="REPLACE WITH PYPI PASSWORD" --add deploy.password
 
 This will:
 


### PR DESCRIPTION
* Cookiecutter version: 1.6.0
* Template project url: https://github.com/rutgerhofste/aqueduct3
* Python version: 3.5
* Operating System: Windows 10 64 bit

### Description:

Add encrypted pypi password to travis.yaml file. The suggested command  (`travis encrypt --add deploy.password`) in the docs has a poor user experience and caused problems on Windows. Suggested improved user experience by switching to:
`travis encrypt SOMEVAR="REPLACE WITH PYPI PASSWORD" --add deploy.password`

[docs](https://docs.travis-ci.com/user/encryption-keys/)

### What I've run:

```
travis encrypt --add deploy.password
```