### PR TITLE
Remove unnecessary ReadTheDocs instruction

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -134,8 +134,6 @@ Log into your account at `ReadTheDocs`_ . If you don't have one, create one and 
 
 If you are not at your dashboard, choose the pull-down next to your username in the upper right, and select "My Projects". Choose the button to Import the repository and follow the directions.
 
-In your GitHub repo, select Settings > Webhooks & Services, turn on the ReadTheDocs service hook.
-
 Now your documentation will get rebuilt when you make documentation changes to your package.
 
 .. _`ReadTheDocs`: https://readthedocs.org/


### PR DESCRIPTION
ReadTheDocs is no longer a GitHub Service, it's now a GitHub App, so it automatically generates a webhook for itself.