### PR TITLE
Fix py.test projects failing to import package

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -14,9 +14,6 @@ if __name__ == '__main__':
         remove_file('AUTHORS.rst')
         remove_file('docs/authors.rst')
 
-    if '{{ cookiecutter.use_pytest }}' == 'y':
-        remove_file('tests/__init__.py')
-
     if 'no' in '{{ cookiecutter.command_line_interface|lower }}':
         cli_file = os.path.join('{{ cookiecutter.project_slug }}', 'cli.py')
         remove_file(cli_file)


### PR DESCRIPTION
Without this, you get 
```
py.test
================================ test session starts =================================
platform linux -- Python 3.7.1, pytest-3.8.2, py-1.7.0, pluggy-0.8.0
rootdir: /home/hayden/code/cache/old-cachepath, inifile: setup.cfg
collected 0 items / 1 errors                                                         

======================================= ERRORS =======================================
______________________ ERROR collecting tests/test_cachepath.py ______________________
ImportError while importing test module '/home/hayden/code/cache/old-cachepath/tests/test_cachepath.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../cachepath/tests/test_cachepath.py:9: in <module>
    from cachepath import cachepath
E   ModuleNotFoundError: No module named 'cachepath'
!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 errors during collection !!!!!!!!!!!!!!!!!!!!!!!
============================== 1 error in 0.07 seconds ===============================
make: *** [Makefile:57: test] Error 2
```