### PR TITLE
Modify find_packages usage to find slug.* modules

### DIFF
--- a/{{cookiecutter.project_slug}}/setup.py
+++ b/{{cookiecutter.project_slug}}/setup.py
@@ -59,7 +59,7 @@ setup(
     include_package_data=True,
     keywords='{{ cookiecutter.project_slug }}',
     name='{{ cookiecutter.project_slug }}',
-    packages=find_packages(include=['{{ cookiecutter.project_slug }}']),
+    packages=find_packages(include=['{{ cookiecutter.project_slug }}', '{{ cookiecutter.project_slug }}.*']),
     setup_requires=setup_requirements,
     test_suite='tests',
     tests_require=test_requirements,


### PR DESCRIPTION
Modify find_packages use in setup.py to find packages named `slug` or `slug.*`, where slug is the `project_slug`.

You can see that currently, only the root module is detected by find_packages. With the proposed fix, submodules are also detected.

Here is a MWE:
```
$ cookiecutter --no-input gh:audreyr/cookiecutter-pypackage
$ cd python_boilerplate
$ mkdir python_boilerplate/{foo, bar}
$ touch python_boilerplate/{foo, bar}/__init__.py
$ python -c 'import setuptools;print(setuptools.find_packages(include=["python_boilerplate"]))'
['python_boilerplate']
$ python -c 'import setuptools;print(setuptools.find_packages(include=["python_boilerplate", "python_boilerplate.*"]))'
['python_boilerplate', 'python_boilerplate.foo', 'python_boilerplate.bar']
```

Would close #423 