### PR TITLE
Add briggySmalls fork to list of alternatives

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Cookiecutter PyPackage
      :alt: Updates
 
 .. image:: https://travis-ci.org/audreyr/cookiecutter-pypackage.svg?branch=master
-    :target: https://travis-ci.org/audreyr/cookiecutter-pypackage     
+    :target: https://travis-ci.org/audreyr/cookiecutter-pypackage
 
 Cookiecutter_ template for a Python package.
 
@@ -96,9 +96,11 @@ Similar Cookiecutter Templates
 
 * `lgiordani/cookiecutter-pypackage`_: A fork of Cookiecutter that uses Punch_ instead of Bumpversion_ and with separate requirements files.
 
+* `briggySmalls/cookiecutter-pypackage`_: A fork using Pipenv_ for package management, with linting, formatting and more.
+
 * Also see the `network`_ and `family tree`_ for this repo. (If you find
   anything that should be listed here, please add it and send a pull request!)
-  
+
 Support this Project
 ~~~~~~~~~~~~~~~~~~~~~
 
@@ -145,12 +147,14 @@ make my own packaging experience better.
 .. _`pyup.io`: https://pyup.io/
 .. _Bumpversion: https://github.com/peritus/bumpversion
 .. _Punch: https://github.com/lgiordani/punch
+.. _Pipenv: https://pipenv.readthedocs.io/en/latest/
 .. _PyPi: https://pypi.python.org/pypi
 
 .. _`Nekroze/cookiecutter-pypackage`: https://github.com/Nekroze/cookiecutter-pypackage
 .. _`tony/cookiecutter-pypackage-pythonic`: https://github.com/tony/cookiecutter-pypackage-pythonic
 .. _`ardydedase/cookiecutter-pypackage`: https://github.com/ardydedase/cookiecutter-pypackage
 .. _`lgiordani/cookiecutter-pypackage`: https://github.com/lgiordani/cookiecutter-pypackage
+.. _`briggySmalls/cookiecutter-pypackage`: https://github.com/briggySmalls/cookiecutter-pypackage
 .. _github comparison view: https://github.com/tony/cookiecutter-pypackage-pythonic/compare/audreyr:master...master
 .. _`network`: https://github.com/audreyr/cookiecutter-pypackage/network
 .. _`family tree`: https://github.com/audreyr/cookiecutter-pypackage/network/members


### PR DESCRIPTION
Hi.

Thanks for the great tool.

I've been dogfooding my own variant for a couple of projects, and I've now plucked up the courage to submit it!

You can have a look at the project at [github.com/briggySmalls/cookiecutter-pypackage](https://github.com/briggySmalls/cookiecutter-pypackage).

The differences are:

* Dependency tracking using pipenv
* Linting provided by both pylint and flake8 [executed by Tox]
* Formatting provided by yapf and isort [checked by Tox]
* Autodoc your code from Google docstring style (optional)
* All development tasks (lint, format, test, etc) wrapped up in a python CLI by invoke

Hopefully you agree to adding it to the repo.

Thanks again! ✌️