### PR TITLE
Add Argparse CLI option, unit test and documentation

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -10,7 +10,7 @@
   "use_pytest": "n",
   "use_pypi_deployment_with_travis": "y",
   "add_pyup_badge": "n",
-  "command_line_interface": ["Click", "No command-line interface"],
+  "command_line_interface": ["Click", "Argparse", "No command-line interface"],
   "create_author_file": "y",
   "open_source_license": ["MIT license", "BSD license", "ISC license", "Apache Software License 2.0", "GNU General Public License v3", "Not open source"]
 }

--- a/docs/console_script_setup.rst
+++ b/docs/console_script_setup.rst
@@ -4,12 +4,12 @@
 Console Script Setup
 =================
 
-Optionally, your package can include a console script
+Optionally, your package can include a console script using Click or argparse (Python 3.2+).
 
 How It Works
 ------------
 
-If the 'command_line_interface' option is set to ['click'] during setup, cookiecutter will
+If the 'command_line_interface' option is set to ['click'] or ['argparse'] during setup, cookiecutter will
 add a file 'cli.py' in the project_slug subdirectory. An entry point is added to
 setup.py that points to the main function in cli.py.
 
@@ -30,7 +30,7 @@ The script will be generated with output for no arguments and --help.
 
 Known Issues
 ------------
-Installing the project in a development environment using:
+Using Click, installing the project in a development environment using:
 
 .. code-block:: bash
 

--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -238,8 +238,45 @@ def test_bake_with_console_script_files(cookies):
         assert 'entry_points' in setup_file.read()
 
 
+def test_bake_with_argparse_console_script_files(cookies):
+    context = {'command_line_interface': 'argparse'}
+    result = cookies.bake(extra_context=context)
+    project_path, project_slug, project_dir = project_info(result)
+    found_project_files = os.listdir(project_dir)
+    assert "cli.py" in found_project_files
+
+    setup_path = os.path.join(project_path, 'setup.py')
+    with open(setup_path, 'r') as setup_file:
+        assert 'entry_points' in setup_file.read()
+
+
 def test_bake_with_console_script_cli(cookies):
     context = {'command_line_interface': 'click'}
+    result = cookies.bake(extra_context=context)
+    project_path, project_slug, project_dir = project_info(result)
+    module_path = os.path.join(project_dir, 'cli.py')
+    module_name = '.'.join([project_slug, 'cli'])
+    if sys.version_info >= (3, 5):
+        spec = importlib.util.spec_from_file_location(module_name, module_path)
+        cli = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(cli)
+    elif sys.version_info >= (3, 3):
+        file_loader = importlib.machinery.SourceFileLoader
+        cli = file_loader(module_name, module_path).load_module()
+    else:
+        cli = imp.load_source(module_name, module_path)
+    runner = CliRunner()
+    noarg_result = runner.invoke(cli.main)
+    assert noarg_result.exit_code == 0
+    noarg_output = ' '.join(['Replace this message by putting your code into', project_slug])
+    assert noarg_output in noarg_result.output
+    help_result = runner.invoke(cli.main, ['--help'])
+    assert help_result.exit_code == 0
+    assert 'Show this message' in help_result.output
+
+
+def test_bake_with_argparse_console_script_cli(cookies):
+    context = {'command_line_interface': 'argparse'}
     result = cookies.bake(extra_context=context)
     project_path, project_slug, project_dir = project_info(result)
     module_path = os.path.join(project_dir, 'cli.py')

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/cli.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/cli.py
@@ -1,10 +1,16 @@
 # -*- coding: utf-8 -*-
 
 """Console script for {{cookiecutter.project_slug}}."""
+
+{%- if cookiecutter.command_line_interface|lower == 'argparse' %}
+import argparse
+{%- endif %}
 import sys
+{%- if cookiecutter.command_line_interface|lower == 'click' %}
 import click
+{%- endif %}
 
-
+{% if cookiecutter.command_line_interface|lower == 'click' %}
 @click.command()
 def main(args=None):
     """Console script for {{cookiecutter.project_slug}}."""
@@ -12,6 +18,19 @@ def main(args=None):
                "{{cookiecutter.project_slug}}.cli.main")
     click.echo("See click documentation at http://click.pocoo.org/")
     return 0
+{%- endif %}
+{%- if cookiecutter.command_line_interface|lower == 'argparse' %}
+def main():
+    """Console script for {{cookiecutter.project_slug}}."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument('_', nargs='*')
+    args = parser.parse_args()
+
+    print("Arguments: " + str(args._))
+    print("Replace this message by putting your code into "
+          "{{cookiecutter.project_slug}}.cli.main")
+    return 0
+{%- endif %}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This request creates an additional option to use argparse for console scripts. I realized rather late into the process that argparse was only added in Python 3.2, so this isn't likely to meet the criteria of Python 2.7 support. Figured I would submit it for conversation's sake and would very much appreciate any feedback.