### PR TITLE
fixes: if Click is choosen it doesn't show up in the requirements_dev.txt

### DIFF
--- a/{{cookiecutter.project_slug}}/requirements_dev.txt
+++ b/{{cookiecutter.project_slug}}/requirements_dev.txt
@@ -7,6 +7,9 @@ tox==3.5.2
 coverage==4.5.1
 Sphinx==1.8.1
 twine==1.12.1
+{% if cookiecutter.command_line_interface|lower == 'click' -%}
+Click>=6.0
+{% endif %}
 {% if cookiecutter.command_line_interface == 'y' -%}
 click==6.7{% endif %}
 {% if cookiecutter.use_pytest == 'y' -%}


### PR DESCRIPTION
Hi, there's a tiny bug in the requirements_dev.txt Template which prevents correct representation of the selected command_line_interface option. If 'Click' is choosen it shows up in the Project's `setup.py` but not in its `requirements_dev.txt`. This patch fixes this tiny problem. Greetings & thanks for your awesome project, Sven
