### PR TITLE
Use maintained bump2version instead of abandoned bumpversion

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ Features
 * Travis-CI_: Ready for Travis Continuous Integration testing
 * Tox_ testing: Setup to easily test for Python 2.7, 3.4, 3.5, 3.6
 * Sphinx_ docs: Documentation ready for generation with, for example, ReadTheDocs_
-* Bumpversion_: Pre-configured version bumping with a single command
+* bump2version_: Pre-configured version bumping with a single command
 * Auto-release to PyPI_ when you push a new tag to master (optional)
 * Command line interface using Click (optional)
 
@@ -94,7 +94,7 @@ Similar Cookiecutter Templates
 
 * `ardydedase/cookiecutter-pypackage`_: A fork with separate requirements files rather than a requirements list in the ``setup.py`` file.
 
-* `lgiordani/cookiecutter-pypackage`_: A fork of Cookiecutter that uses Punch_ instead of Bumpversion_ and with separate requirements files.
+* `lgiordani/cookiecutter-pypackage`_: A fork of Cookiecutter that uses Punch_ instead of bump2version_ and with separate requirements files.
 
 * Also see the `network`_ and `family tree`_ for this repo. (If you find
   anything that should be listed here, please add it and send a pull request!)
@@ -143,7 +143,7 @@ make my own packaging experience better.
 .. _Sphinx: http://sphinx-doc.org/
 .. _ReadTheDocs: https://readthedocs.io/
 .. _`pyup.io`: https://pyup.io/
-.. _Bumpversion: https://github.com/peritus/bumpversion
+.. _bump2version: https://github.com/c4urself/bump2version
 .. _Punch: https://github.com/lgiordani/punch
 .. _PyPi: https://pypi.python.org/pypi
 

--- a/docs/pypi_release_checklist.rst
+++ b/docs/pypi_release_checklist.rst
@@ -28,7 +28,7 @@ For Every Release
 
     .. code-block:: bash
 
-        bumpversion minor
+        bump2version minor
 
 #. Install the package again for local development, but with the new version number:
 

--- a/docs/travis_pypi_setup.rst
+++ b/docs/travis_pypi_setup.rst
@@ -8,11 +8,11 @@ Optionally, your package can automatically be released on PyPI whenever you
 push a new tag to the master branch.
 
 Install the Travis CLI tool
---------------------------------------
+----------------------------
 
 This is OS-specific.
 
-### Mac OS X
+### macOS
 
 We recommend the Homebrew travis package:
 
@@ -43,7 +43,7 @@ If you are using this feature, this is how you would do a patch release:
 
 .. code-block:: bash
 
-    bumpversion patch
+    bump2version patch
     git push --tags
 
 This will result in:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.1
+current_version = 0.5.10
 commit = True
 tag = True
 

--- a/{{cookiecutter.project_slug}}/CONTRIBUTING.rst
+++ b/{{cookiecutter.project_slug}}/CONTRIBUTING.rst
@@ -124,7 +124,7 @@ A reminder for the maintainers on how to deploy.
 Make sure all your changes are committed (including an entry in HISTORY.rst).
 Then run::
 
-$ bumpversion patch # possible: major / minor / patch
+$ bump2version patch # possible: major / minor / patch
 $ git push
 $ git push --tags
 

--- a/{{cookiecutter.project_slug}}/requirements_dev.txt
+++ b/{{cookiecutter.project_slug}}/requirements_dev.txt
@@ -1,5 +1,5 @@
 pip==18.1
-bumpversion==0.5.3
+bump2version==0.5.10
 wheel==0.32.1
 watchdog==0.9.0
 flake8==3.5.0


### PR DESCRIPTION
Fixes #424, fixes #437.

> I should probably add a sunsetting notice to the top of the README, saying this is not actively maintained and people should switch to one of the forked versions.

24 Oct 2017, https://github.com/peritus/bumpversion/issues/169#issuecomment-339023681