### PR TITLE
Drop support for EOL Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: python
 python:
   - 3.6
   - 3.5
-  - 3.4
   - 2.7
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -135,7 +135,7 @@ Before you submit a pull request, check that it meets these guidelines:
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
 
-3. The pull request should work for Python 2.7, 3.4, 3.5 and 3.6, and for PyPy. Check
+3. The pull request should work for Python 2.7, 3.5 and 3.6, and for PyPy. Check
    https://travis-ci.org/audreyr/cookiecutter-pypackage/pull_requests
    and make sure that the tests pass for all supported Python versions.
 

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Features
 
 * Testing setup with ``unittest`` and ``python setup.py test`` or ``py.test``
 * Travis-CI_: Ready for Travis Continuous Integration testing
-* Tox_ testing: Setup to easily test for Python 2.7, 3.4, 3.5, 3.6
+* Tox_ testing: Setup to easily test for Python 2.7, 3.5, 3.6
 * Sphinx_ docs: Documentation ready for generation with, for example, ReadTheDocs_
 * Bumpversion_: Pre-configured version bumping with a single command
 * Auto-release to PyPI_ when you push a new tag to master (optional)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,12 +9,6 @@ environment:
     - PYTHON: "C:\\Python27-x64"
       TOX_ENV: "py27"
 
-    - PYTHON: "C:\\Python34"
-      TOX_ENV: "py34"
-
-    - PYTHON: "C:\\Python34-x64"
-      TOX_ENV: "py34"
-
     - PYTHON: "C:\\Python35"
       TOX_ENV: "py35"
 

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
     author_email='aroy@alum.mit.edu',
     url='https://github.com/audreyr/cookiecutter-pypackage',
     keywords=['cookiecutter', 'template', 'package', ],
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',
@@ -21,7 +22,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: CPython',

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 [tox]
-envlist = py27, py34, py35, py36, pypy, docs
+envlist = py27, py35, py36, pypy, docs
 skipsdist = true
 
 [travis]
 python =
     3.6: py36
     3.5: py35
-    3.4: py34
     2.7: py27
 
 [testenv:docs]
@@ -23,4 +22,4 @@ deps =
     -r{toxinidir}/requirements_dev.txt
 commands =
     pip install -U pip
-    py.test
+    pytest

--- a/{{cookiecutter.project_slug}}/.travis.yml
+++ b/{{cookiecutter.project_slug}}/.travis.yml
@@ -4,7 +4,6 @@ language: python
 python:
   - 3.6
   - 3.5
-  - 3.4
   - 2.7
 
 # Command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors

--- a/{{cookiecutter.project_slug}}/CONTRIBUTING.rst
+++ b/{{cookiecutter.project_slug}}/CONTRIBUTING.rst
@@ -102,7 +102,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.7, 3.4, 3.5 and 3.6, and for PyPy. Check
+3. The pull request should work for Python 2.7, 3.5 and 3.6, and for PyPy. Check
    https://travis-ci.org/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}/pull_requests
    and make sure that the tests pass for all supported Python versions.
 

--- a/{{cookiecutter.project_slug}}/setup.py
+++ b/{{cookiecutter.project_slug}}/setup.py
@@ -28,6 +28,7 @@ test_requirements = [{%- if cookiecutter.use_pytest == 'y' %}'pytest',{%- endif 
 setup(
     author="{{ cookiecutter.full_name.replace('\"', '\\\"') }}",
     author_email='{{ cookiecutter.email }}',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',
         'Intended Audience :: Developers',
@@ -38,7 +39,6 @@ setup(
         "Programming Language :: Python :: 2",
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/{{cookiecutter.project_slug}}/tox.ini
+++ b/{{cookiecutter.project_slug}}/tox.ini
@@ -1,11 +1,10 @@
 [tox]
-envlist = py27, py34, py35, py36, flake8
+envlist = py27, py35, py36, flake8
 
 [travis]
 python =
     3.6: py36
     3.5: py35
-    3.4: py34
     2.7: py27
 
 [testenv:flake8]


### PR DESCRIPTION
Python 3.4 is EOL and no longer receiving security updates (or any updates) from the core Python team.

Version | Release date | Supported until
--- | ---------- | ----------
2.7 | 2010-07-03 | 2020-01-01
3.4 | 2014-03-16 | 2019-03-16

Source: https://en.wikipedia.org/wiki/CPython#Version_history

It's also little used. Here's the pip installs for `cookiecutter` from PyPI for June 2019:

| category | percent | downloads |
|----------|--------:|----------:|
| 3.7      |  49.40% |   152,691 |
| 2.7      |  24.74% |    76,463 |
| 3.6      |  20.75% |    64,135 |
| 3.5      |   4.54% |    14,030 |
| null     |   0.32% |       976 |
| 3.4      |   0.20% |       605 |
| 3.8      |   0.06% |       182 |
| 3.3      |   0.00% |         8 |
| 2.6      |   0.00% |         3 |
| 3.2      |   0.00% |         1 |
| 3.9      |   0.00% |         1 |
| Total    |         |   309,095 |

Source: `pypistats python_minor cookiecutter --last-month # pip install pypistats`

Additionally, Python 3.4 is failing on Travis CI. This make Travis green.
