### PR TITLE
Remove python3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: python
 python:
   - 3.6
   - 3.5
-  - 3.4
   - 2.7
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -135,7 +135,7 @@ Before you submit a pull request, check that it meets these guidelines:
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
 
-3. The pull request should work for Python 2.7, 3.4, 3.5 and 3.6, and for PyPy. Check
+3. The pull request should work for Python 2.7, 3.5 and 3.6, and for PyPy. Check
    https://travis-ci.org/audreyr/cookiecutter-pypackage/pull_requests
    and make sure that the tests pass for all supported Python versions.
 

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Cookiecutter PyPackage
      :alt: Updates
 
 .. image:: https://travis-ci.org/audreyr/cookiecutter-pypackage.svg?branch=master
-    :target: https://travis-ci.org/audreyr/cookiecutter-pypackage     
+    :target: https://travis-ci.org/audreyr/cookiecutter-pypackage
 
 Cookiecutter_ template for a Python package.
 
@@ -20,7 +20,7 @@ Features
 
 * Testing setup with ``unittest`` and ``python setup.py test`` or ``py.test``
 * Travis-CI_: Ready for Travis Continuous Integration testing
-* Tox_ testing: Setup to easily test for Python 2.7, 3.4, 3.5, 3.6
+* Tox_ testing: Setup to easily test for Python 2.7, 3.5, 3.6
 * Sphinx_ docs: Documentation ready for generation with, for example, ReadTheDocs_
 * Bumpversion_: Pre-configured version bumping with a single command
 * Auto-release to PyPI_ when you push a new tag to master (optional)
@@ -98,7 +98,7 @@ Similar Cookiecutter Templates
 
 * Also see the `network`_ and `family tree`_ for this repo. (If you find
   anything that should be listed here, please add it and send a pull request!)
-  
+
 Support this Project
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,12 +9,6 @@ environment:
     - PYTHON: "C:\\Python27-x64"
       TOX_ENV: "py27"
 
-    - PYTHON: "C:\\Python34"
-      TOX_ENV: "py34"
-
-    - PYTHON: "C:\\Python34-x64"
-      TOX_ENV: "py34"
-
     - PYTHON: "C:\\Python35"
       TOX_ENV: "py35"
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: CPython',

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 [tox]
-envlist = py27, py34, py35, py36, pypy, docs
+envlist = py27, py35, py36, pypy, docs
 skipsdist = true
 
 [travis]
 python =
     3.6: py36
     3.5: py35
-    3.4: py34
     2.7: py27
 
 [testenv:docs]

--- a/{{cookiecutter.project_slug}}/.travis.yml
+++ b/{{cookiecutter.project_slug}}/.travis.yml
@@ -4,7 +4,6 @@ language: python
 python:
   - 3.6
   - 3.5
-  - 3.4
   - 2.7
 
 # Command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors

--- a/{{cookiecutter.project_slug}}/CONTRIBUTING.rst
+++ b/{{cookiecutter.project_slug}}/CONTRIBUTING.rst
@@ -102,7 +102,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.7, 3.4, 3.5 and 3.6, and for PyPy. Check
+3. The pull request should work for Python 2.7, 3.5 and 3.6, and for PyPy. Check
    https://travis-ci.org/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}/pull_requests
    and make sure that the tests pass for all supported Python versions.
 

--- a/{{cookiecutter.project_slug}}/setup.py
+++ b/{{cookiecutter.project_slug}}/setup.py
@@ -38,7 +38,6 @@ setup(
         "Programming Language :: Python :: 2",
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/{{cookiecutter.project_slug}}/tox.ini
+++ b/{{cookiecutter.project_slug}}/tox.ini
@@ -1,11 +1,10 @@
 [tox]
-envlist = py27, py34, py35, py36, flake8
+envlist = py27, py35, py36, flake8
 
 [travis]
 python =
     3.6: py36
     3.5: py35
-    3.4: py34
     2.7: py27
 
 [testenv:flake8]


### PR DESCRIPTION
Such as the title. Python 3.4 is currently in EOL state, so remove it.