### PR TITLE
Update pytest 3.4.2 -> 4.6.5

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
-pytest==3.4.2
+pytest==4.6.5
 tox==3.14.0
 cookiecutter>=1.4.0
 pytest-cookies==0.4.0


### PR DESCRIPTION
In the months to come, we need to guarantee python 2.7 support.