### PR TITLE
Bundle all the dependencies in a pipenv

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -7,6 +7,7 @@
   "project_short_description": "Python Boilerplate contains all the boilerplate you need to create a Python package.",
   "pypi_username": "{{ cookiecutter.github_username }}",
   "version": "0.1.0",
+  "use_pipenv": "n",
   "use_pytest": "n",
   "use_pypi_deployment_with_travis": "y",
   "add_pyup_badge": "n",

--- a/{{cookiecutter.project_slug}}/.travis.yml
+++ b/{{cookiecutter.project_slug}}/.travis.yml
@@ -8,10 +8,10 @@ python:
   - 2.7
 
 # Command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
-install: pip install -U tox-travis
+install: {% if cookiecutter.use_pipenv == 'y' %}pipenv{% else %}pip{% endif %} install -U tox-travis
 
 # Command to run tests, e.g. python setup.py test
-script: tox
+script: {% if cookiecutter.use_pipenv == 'y' %}pipenv run {% endif %}tox
 
 {% if cookiecutter.use_pypi_deployment_with_travis == 'y' -%}
 # Assuming you have installed the travis-ci CLI tool, after you

--- a/{{cookiecutter.project_slug}}/CONTRIBUTING.rst
+++ b/{{cookiecutter.project_slug}}/CONTRIBUTING.rst
@@ -64,11 +64,18 @@ Ready to contribute? Here's how to set up `{{ cookiecutter.project_slug }}` for 
 
     $ git clone git@github.com:your_name_here/{{ cookiecutter.project_slug }}.git
 
+{%- if cookiecutter.use_pipenv == 'y' %}
+3. Assuming you have pipenv installed, you can **create a new environment with all the dependencies** by typing::
+
+    $ make init
+    $ pipenv shell
+{%- else %}
 3. Install your local copy into a virtualenv. Assuming you have virtualenvwrapper installed, this is how you set up your fork for local development::
 
     $ mkvirtualenv {{ cookiecutter.project_slug }}
     $ cd {{ cookiecutter.project_slug }}/
     $ python setup.py develop
+{%- endif %}
 
 4. Create a branch for local development::
 

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -71,7 +71,7 @@ test: ## run tests quickly with the default Python
 {%- endif %}
 
 test-all: ## run tests on every Python version with tox
-	tox
+	$(ENVIRONMENT) tox
 
 coverage: ## check code coverage quickly with the default Python
 {%- if cookiecutter.use_pytest == 'y' %}

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -26,8 +26,18 @@ export PRINT_HELP_PYSCRIPT
 
 BROWSER := python -c "$$BROWSER_PYSCRIPT"
 
+ENVIRONMENT := {% if cookiecutter.use_pipenv == 'y' %}pipenv run {% endif %}
+
 help:
 	@python -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
+
+{%- if cookiecutter.use_pipenv == 'y' %}
+init:	
+	pipenv --three
+	pipenv install --dev --skip-lock
+	pipenv install -r requirements_dev.txt
+	pipenv run python setup.py develop
+{%- endif %}
 
 clean: clean-build clean-pyc clean-test ## remove all build, test, coverage and Python artifacts
 
@@ -51,13 +61,13 @@ clean-test: ## remove test and coverage artifacts
 	rm -fr .pytest_cache
 
 lint: ## check style with flake8
-	flake8 {{ cookiecutter.project_slug }} tests
+	$(ENVIRONMENT) flake8 {{ cookiecutter.project_slug }} tests
 
 test: ## run tests quickly with the default Python
 {%- if cookiecutter.use_pytest == 'y' %}
-	pytest
+	$(ENVIRONMENT) pytest
 {%- else %}
-	python setup.py test
+	$(ENVIRONMENT) python setup.py test
 {%- endif %}
 
 test-all: ## run tests on every Python version with tox
@@ -65,32 +75,32 @@ test-all: ## run tests on every Python version with tox
 
 coverage: ## check code coverage quickly with the default Python
 {%- if cookiecutter.use_pytest == 'y' %}
-	coverage run --source {{ cookiecutter.project_slug }} -m pytest
+	$(ENVIRONMENT) coverage run --source {{ cookiecutter.project_slug }} -m pytest
 {%- else %}
-	coverage run --source {{ cookiecutter.project_slug }} setup.py test
+	$(ENVIRONMENT) coverage run --source {{ cookiecutter.project_slug }} setup.py test
 {%- endif %}
-	coverage report -m
-	coverage html
+	$(ENVIRONMENT) coverage report -m
+	$(ENVIRONMENT) coverage html
 	$(BROWSER) htmlcov/index.html
 
 docs: ## generate Sphinx HTML documentation, including API docs
 	rm -f docs/{{ cookiecutter.project_slug }}.rst
 	rm -f docs/modules.rst
-	sphinx-apidoc -o docs/ {{ cookiecutter.project_slug }}
+	$(ENVIRONMENT) sphinx-apidoc -o docs/ {{ cookiecutter.project_slug }}
 	$(MAKE) -C docs clean
 	$(MAKE) -C docs html
 	$(BROWSER) docs/_build/html/index.html
 
 servedocs: docs ## compile the docs watching for changes
-	watchmedo shell-command -p '*.rst' -c '$(MAKE) -C docs html' -R -D .
+	$(ENVIRONMENT) watchmedo shell-command -p '*.rst' -c '$(MAKE) -C docs html' -R -D .
 
 release: dist ## package and upload a release
-	twine upload dist/*
+	$(ENVIRONMENT) twine upload dist/*
 
 dist: clean ## builds source and wheel package
-	python setup.py sdist
-	python setup.py bdist_wheel
+	$(ENVIRONMENT) python setup.py sdist
+	$(ENVIRONMENT) python setup.py bdist_wheel
 	ls -l dist
 
 install: clean ## install the package to the active Python's site-packages
-	python setup.py install
+	$(ENVIRONMENT) python setup.py install

--- a/{{cookiecutter.project_slug}}/docs/Makefile
+++ b/{{cookiecutter.project_slug}}/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD   = python -msphinx
+SPHINXBUILD   = {% if cookiecutter.use_pipenv == 'y' %}pipenv run {% endif %}python -m sphinx
 SPHINXPROJ    = {{ cookiecutter.project_slug }}
 SOURCEDIR     = .
 BUILDDIR      = _build

--- a/{{cookiecutter.project_slug}}/tox.ini
+++ b/{{cookiecutter.project_slug}}/tox.ini
@@ -10,21 +10,27 @@ python =
 
 [testenv:flake8]
 basepython = python
-deps = flake8
-commands = flake8 {{ cookiecutter.project_slug }}
+deps =
+    flake8
+    {% if cookiecutter.use_pipenv == 'y' %}pipenv{% endif %}
+commands =
+    {% if cookiecutter.use_pipenv == 'y' %}pipenv install --dev{% endif %}
+    {% if cookiecutter.use_pipenv == 'y' %}pipenv run {% endif %} flake8 {{ cookiecutter.project_slug }}
 
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}
-{% if cookiecutter.use_pytest == 'y' -%}
+{%- if cookiecutter.use_pytest == 'y' %}
 deps =
     -r{toxinidir}/requirements_dev.txt
+	{% if cookiecutter.use_pipenv == 'y' %}pipenv{% endif %}
 ; If you want to make tox run the tests with the same versions, create a
 ; requirements.txt with the pinned versions and uncomment the following line:
 ;     -r{toxinidir}/requirements.txt
 commands =
-    pip install -U pip
-    pytest --basetemp={envtmpdir}
-{% else %}
-commands = python setup.py test
+    {% if cookiecutter.use_pipenv == 'y' %}pipenv install --dev {% else %}pip install -U pip{% endif %}
+    {% if cookiecutter.use_pipenv == 'y' %}pipenv run {% endif %} pytest --basetemp={envtmpdir}
+{%- else %}
+commands =
+    {% if cookiecutter.use_pipenv == 'y' %}pipenv run {% endif %} python setup.py test
 {%- endif %}


### PR DESCRIPTION
Add make rules to encapsulate all the operation in a pipenv.

Makes sharing / developping the generated package easier.