### PR TITLE
Remove python 2.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,7 @@ target/
 # Cookiecutter
 output/
 python_boilerplate/
+cookiecutter-pypackage-env/
+
+# IDE settings
+.vscode/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python:
   - 3.7
   - 3.6
   - 3.5
-  - 2.7
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: pip install -U tox-travis
@@ -24,4 +23,4 @@ deploy:
   on:
     tags: true
     repo: audreyr/python_boilerplate
-    python: 2.7
+    python: 3.8

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -171,7 +171,7 @@ Before you submit a pull request, check that it meets these guidelines:
    new functionality into a function with a docstring, and add the feature to
    the list in README.rst.
 
-3. The pull request should work for Python 2.7, 3.5, 3.6 and 3.7, 3.8 and for PyPy. Check
+3. The pull request should work for Python 3.5, 3.6 and 3.7, 3.8 and for PyPy. Check
    https://travis-ci.org/audreyr/cookiecutter-pypackage/pull_requests and
    make sure that the tests pass for all supported Python versions.
 

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Features
 
 * Testing setup with ``unittest`` and ``python setup.py test`` or ``pytest``
 * Travis-CI_: Ready for Travis Continuous Integration testing
-* Tox_ testing: Setup to easily test for Python 2.7, 3.5, 3.6, 3.7
+* Tox_ testing: Setup to easily test for Python 3.5, 3.6, 3.7, 3.8
 * Sphinx_ docs: Documentation ready for generation with, for example, ReadTheDocs_
 * bump2version_: Pre-configured version bumping with a single command
 * Auto-release to PyPI_ when you push a new tag to master (optional)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,12 +3,6 @@
 
 environment:
   matrix:
-    - PYTHON: "C:\\Python27"
-      TOX_ENV: "py27"
-
-    - PYTHON: "C:\\Python27-x64"
-      TOX_ENV: "py27"
-
     - PYTHON: "C:\\Python35"
       TOX_ENV: "py35"
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     author_email='aroy@alum.mit.edu',
     url='https://github.com/audreyr/cookiecutter-pypackage',
     keywords=['cookiecutter', 'template', 'package', ],
-    python_requires='>=3.5, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
+    python_requires='>=3.5',
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     author_email='aroy@alum.mit.edu',
     url='https://github.com/audreyr/cookiecutter-pypackage',
     keywords=['cookiecutter', 'template', 'package', ],
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
+    python_requires='>=3.5, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',
@@ -19,8 +19,6 @@ setup(
         'Natural Language :: English',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -96,14 +96,20 @@ def test_bake_and_run_tests(cookies):
 
 def test_bake_withspecialchars_and_run_tests(cookies):
     """Ensure that a `full_name` with double quotes does not break setup.py"""
-    with bake_in_temp_dir(cookies, extra_context={'full_name': 'name "quote" name'}) as result:
+    with bake_in_temp_dir(
+        cookies,
+        extra_context={'full_name': 'name "quote" name'}
+    ) as result:
         assert result.project.isdir()
         run_inside_dir('python setup.py test', str(result.project)) == 0
 
 
 def test_bake_with_apostrophe_and_run_tests(cookies):
     """Ensure that a `full_name` with apostrophes does not break setup.py"""
-    with bake_in_temp_dir(cookies, extra_context={'full_name': "O'connor"}) as result:
+    with bake_in_temp_dir(
+        cookies,
+        extra_context={'full_name': "O'connor"}
+    ) as result:
         assert result.project.isdir()
         run_inside_dir('python setup.py test', str(result.project)) == 0
 
@@ -115,24 +121,38 @@ def test_bake_with_apostrophe_and_run_tests(cookies):
 #
 #         # when:
 #         travis_setup_cmd = ('python travis_pypi_setup.py'
-#                             ' --repo audreyr/cookiecutter-pypackage --password invalidpass')
+#                             ' --repo audreyr/cookiecutter-pypackage'
+#                             ' --password invalidpass')
 #         run_inside_dir(travis_setup_cmd, project_path)
 #         # then:
-#         result_travis_config = yaml.load(result.project.join(".travis.yml").open())
+#         result_travis_config = yaml.load(
+#             result.project.join(".travis.yml").open()
+#         )
 #         min_size_of_encrypted_password = 50
-#         assert len(result_travis_config["deploy"]["password"]["secure"]) > min_size_of_encrypted_password
+#         assert len(
+#             result_travis_config["deploy"]["password"]["secure"]
+#         ) > min_size_of_encrypted_password
 
 
 def test_bake_without_travis_pypi_setup(cookies):
-    with bake_in_temp_dir(cookies, extra_context={'use_pypi_deployment_with_travis': 'n'}) as result:
-        result_travis_config = yaml.load(result.project.join(".travis.yml").open(), Loader=yaml.FullLoader)
+    with bake_in_temp_dir(
+        cookies,
+        extra_context={'use_pypi_deployment_with_travis': 'n'}
+    ) as result:
+        result_travis_config = yaml.load(
+            result.project.join(".travis.yml").open(),
+            Loader=yaml.FullLoader
+        )
         assert "deploy" not in result_travis_config
         assert "python" == result_travis_config["language"]
-        found_toplevel_files = [f.basename for f in result.project.listdir()]
+        # found_toplevel_files = [f.basename for f in result.project.listdir()]
 
 
 def test_bake_without_author_file(cookies):
-    with bake_in_temp_dir(cookies, extra_context={'create_author_file': 'n'}) as result:
+    with bake_in_temp_dir(
+        cookies,
+        extra_context={'create_author_file': 'n'}
+    ) as result:
         found_toplevel_files = [f.basename for f in result.project.listdir()]
         assert 'AUTHORS.rst' not in found_toplevel_files
         doc_files = [f.basename for f in result.project.join('docs').listdir()]
@@ -151,26 +171,40 @@ def test_bake_without_author_file(cookies):
 
 def test_make_help(cookies):
     with bake_in_temp_dir(cookies) as result:
-        output = check_output_inside_dir('make help', str(result.project))
-        assert b"check code coverage quickly with the default Python" in output
+        # The supplied Makefile does not support win32
+        if sys.platform != "win32":
+            output = check_output_inside_dir(
+                'make help',
+                str(result.project)
+            )
+            assert b"check code coverage quickly with the default Python" in \
+                output
 
 
 def test_bake_selecting_license(cookies):
     license_strings = {
         'MIT license': 'MIT ',
-        'BSD license': 'Redistributions of source code must retain the above copyright notice, this',
+        'BSD license': 'Redistributions of source code must retain the ' +
+                       'above copyright notice, this',
         'ISC license': 'ISC License',
-        'Apache Software License 2.0': 'Licensed under the Apache License, Version 2.0',
+        'Apache Software License 2.0':
+            'Licensed under the Apache License, Version 2.0',
         'GNU General Public License v3': 'GNU GENERAL PUBLIC LICENSE',
     }
     for license, target_string in license_strings.items():
-        with bake_in_temp_dir(cookies, extra_context={'open_source_license': license}) as result:
+        with bake_in_temp_dir(
+            cookies,
+            extra_context={'open_source_license': license}
+        ) as result:
             assert target_string in result.project.join('LICENSE').read()
             assert license in result.project.join('setup.py').read()
 
 
 def test_bake_not_open_source(cookies):
-    with bake_in_temp_dir(cookies, extra_context={'open_source_license': 'Not open source'}) as result:
+    with bake_in_temp_dir(
+        cookies,
+        extra_context={'open_source_license': 'Not open source'}
+    ) as result:
         found_toplevel_files = [f.basename for f in result.project.listdir()]
         assert 'setup.py' in found_toplevel_files
         assert 'LICENSE' not in found_toplevel_files
@@ -178,9 +212,14 @@ def test_bake_not_open_source(cookies):
 
 
 def test_using_pytest(cookies):
-    with bake_in_temp_dir(cookies, extra_context={'use_pytest': 'y'}) as result:
+    with bake_in_temp_dir(
+        cookies,
+        extra_context={'use_pytest': 'y'}
+    ) as result:
         assert result.project.isdir()
-        test_file_path = result.project.join('tests/test_python_boilerplate.py')
+        test_file_path = result.project.join(
+            'tests/test_python_boilerplate.py'
+        )
         lines = test_file_path.readlines()
         assert "import pytest" in ''.join(lines)
         # Test the new pytest target
@@ -192,24 +231,31 @@ def test_using_pytest(cookies):
 def test_not_using_pytest(cookies):
     with bake_in_temp_dir(cookies) as result:
         assert result.project.isdir()
-        test_file_path = result.project.join('tests/test_python_boilerplate.py')
+        test_file_path = result.project.join(
+            'tests/test_python_boilerplate.py'
+        )
         lines = test_file_path.readlines()
         assert "import unittest" in ''.join(lines)
         assert "import pytest" not in ''.join(lines)
 
 
 # def test_project_with_hyphen_in_module_name(cookies):
-#     result = cookies.bake(extra_context={'project_name': 'something-with-a-dash'})
+#     result = cookies.bake(
+#         extra_context={'project_name': 'something-with-a-dash'}
+#     )
 #     assert result.project is not None
 #     project_path = str(result.project)
 #
 #     # when:
 #     travis_setup_cmd = ('python travis_pypi_setup.py'
-#                         ' --repo audreyr/cookiecutter-pypackage --password invalidpass')
+#                         ' --repo audreyr/cookiecutter-pypackage'
+#                         ' --password invalidpass')
 #     run_inside_dir(travis_setup_cmd, project_path)
 #
 #     # then:
-#     result_travis_config = yaml.load(open(os.path.join(project_path, ".travis.yml")))
+#     result_travis_config = yaml.load(
+#         open(os.path.join(project_path, ".travis.yml"))
+#     )
 #     assert "secure" in result_travis_config["deploy"]["password"],\
 #         "missing password config in .travis.yml"
 
@@ -268,7 +314,9 @@ def test_bake_with_console_script_cli(cookies):
     runner = CliRunner()
     noarg_result = runner.invoke(cli.main)
     assert noarg_result.exit_code == 0
-    noarg_output = ' '.join(['Replace this message by putting your code into', project_slug])
+    noarg_output = ' '.join([
+        'Replace this message by putting your code into',
+        project_slug])
     assert noarg_output in noarg_result.output
     help_result = runner.invoke(cli.main, ['--help'])
     assert help_result.exit_code == 0
@@ -293,7 +341,9 @@ def test_bake_with_argparse_console_script_cli(cookies):
     runner = CliRunner()
     noarg_result = runner.invoke(cli.main)
     assert noarg_result.exit_code == 0
-    noarg_output = ' '.join(['Replace this message by putting your code into', project_slug])
+    noarg_output = ' '.join([
+        'Replace this message by putting your code into',
+        project_slug])
     assert noarg_output in noarg_result.output
     help_result = runner.invoke(cli.main, ['--help'])
     assert help_result.exit_code == 0

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36, py37,py38 pypy, docs
+envlist = py35, py36, py37,py38 pypy, docs
 skipsdist = true
 
 [travis]
@@ -8,7 +8,6 @@ python =
     3.7: py37
     3.6: py36
     3.5: py35
-    2.7: py27
 
 [testenv:docs]
 basepython=python

--- a/{{cookiecutter.project_slug}}/.gitignore
+++ b/{{cookiecutter.project_slug}}/.gitignore
@@ -100,3 +100,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# IDE settings
+.vscode/

--- a/{{cookiecutter.project_slug}}/.travis.yml
+++ b/{{cookiecutter.project_slug}}/.travis.yml
@@ -6,7 +6,6 @@ python:
   - 3.7
   - 3.6
   - 3.5
-  - 2.7
 
 # Command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: pip install -U tox-travis

--- a/{{cookiecutter.project_slug}}/CONTRIBUTING.rst
+++ b/{{cookiecutter.project_slug}}/CONTRIBUTING.rst
@@ -102,7 +102,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.7, 3.5, 3.6, 3.7 and 3.8, and for PyPy. Check
+3. The pull request should work for Python 3.5, 3.6, 3.7 and 3.8, and for PyPy. Check
    https://travis-ci.org/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}/pull_requests
    and make sure that the tests pass for all supported Python versions.
 

--- a/{{cookiecutter.project_slug}}/setup.py
+++ b/{{cookiecutter.project_slug}}/setup.py
@@ -28,7 +28,7 @@ test_requirements = [{%- if cookiecutter.use_pytest == 'y' %}'pytest>=3',{%- end
 setup(
     author="{{ cookiecutter.full_name.replace('\"', '\\\"') }}",
     author_email='{{ cookiecutter.email }}',
-    python_requires='>=3.5, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
+    python_requires='>=3.5',
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',
         'Intended Audience :: Developers',

--- a/{{cookiecutter.project_slug}}/setup.py
+++ b/{{cookiecutter.project_slug}}/setup.py
@@ -28,7 +28,7 @@ test_requirements = [{%- if cookiecutter.use_pytest == 'y' %}'pytest>=3',{%- end
 setup(
     author="{{ cookiecutter.full_name.replace('\"', '\\\"') }}",
     author_email='{{ cookiecutter.email }}',
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
+    python_requires='>=3.5, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',
         'Intended Audience :: Developers',
@@ -36,8 +36,6 @@ setup(
         '{{ license_classifiers[cookiecutter.open_source_license] }}',
 {%- endif %}
         'Natural Language :: English',
-        "Programming Language :: Python :: 2",
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/{{cookiecutter.project_slug}}/tox.ini
+++ b/{{cookiecutter.project_slug}}/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36, py37, py38, flake8
+envlist = py35, py36, py37, py38, flake8
 
 [travis]
 python =
@@ -7,7 +7,6 @@ python =
     3.7: py37
     3.6: py36
     3.5: py35
-    2.7: py27
 
 [testenv:flake8]
 basepython = python


### PR DESCRIPTION
Removes all instances of and references Python 2.7 from the codebase as well as cookiecutter.

Fixes #405 - Python 2.7 is end of life in less than 60 days.

Also adds `.vscode` to `.gitignore`, fixes broken test in win32, and resolves all flake8 linting errors