### PR TITLE
Ignoring venv directory in command find

### DIFF
--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -32,14 +32,14 @@ clean-build: ## remove build artifacts
 	rm -fr build/
 	rm -fr dist/
 	rm -fr .eggs/
-	find . -name '*.egg-info' -exec rm -fr {} +
-	find . -name '*.egg' -exec rm -f {} +
+	find . '!' -path './venv/*' -name '*.egg-info' -exec rm -fr {} +
+	find . '!' -path './venv/*' -name '*.egg' -exec rm -f {} +
 
 clean-pyc: ## remove Python file artifacts
-	find . -name '*.pyc' -exec rm -f {} +
-	find . -name '*.pyo' -exec rm -f {} +
-	find . -name '*~' -exec rm -f {} +
-	find . -name '__pycache__' -exec rm -fr {} +
+	find . '!' -path './venv/*' -name '*.pyc' -exec rm -f {} +
+	find . '!' -path './venv/*' -name '*.pyo' -exec rm -f {} +
+	find . '!' -path './venv/*' -name '*~' -exec rm -f {} +
+	find . '!' -path './venv/*' -name '__pycache__' -exec rm -fr {} +
 
 clean-test: ## remove test and coverage artifacts
 	rm -fr .tox/


### PR DESCRIPTION
When searching with find, it is looking in the venv directory (if any) and trying to remove folders with line 36.
When line 36 is executed, there is a failure to find folders containing ".egg", and when trying to remove the folders, the failure is thrown because it does not have the "r" flag in "rm -fr".