### PR TITLE
Tests refactor

### DIFF
--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -87,7 +87,7 @@ def test_bake_with_defaults(cookies):
 def test_bake_and_run_tests(cookies):
     with bake_in_temp_dir(cookies) as result:
         assert result.project.isdir()
-        run_inside_dir('python setup.py test', str(result.project)) == 0
+        run_inside_dir('python setup.py test', str(result.project))
         print("test_bake_and_run_tests path", str(result.project))
 
 
@@ -98,7 +98,7 @@ def test_bake_withspecialchars_and_run_tests(cookies):
         extra_context={'full_name': 'name "quote" name'}
     ) as result:
         assert result.project.isdir()
-        run_inside_dir('python setup.py test', str(result.project)) == 0
+        run_inside_dir('python setup.py test', str(result.project))
 
 
 def test_bake_with_apostrophe_and_run_tests(cookies):
@@ -108,7 +108,7 @@ def test_bake_with_apostrophe_and_run_tests(cookies):
         extra_context={'full_name': "O'connor"}
     ) as result:
         assert result.project.isdir()
-        run_inside_dir('python setup.py test', str(result.project)) == 0
+        run_inside_dir('python setup.py test', str(result.project))
 
 
 # def test_bake_and_run_travis_pypi_setup(cookies):
@@ -220,9 +220,9 @@ def test_using_pytest(cookies):
         lines = test_file_path.readlines()
         assert "import pytest" in ''.join(lines)
         # Test the new pytest target
-        run_inside_dir('python setup.py pytest', str(result.project)) == 0
+        run_inside_dir('python setup.py pytest', str(result.project))
         # Test the test alias (which invokes pytest)
-        run_inside_dir('python setup.py test', str(result.project)) == 0
+        run_inside_dir('python setup.py test', str(result.project))
 
 
 def test_not_using_pytest(cookies):


### PR DESCRIPTION
This mainly uses pytest's parametrization to keep tests DRY.

Some ineffectual code is also removed.

This PR doesn't affect test coverage nor functionality.