### PR TITLE
[Bugfix] Fixed argparse test and added cli assertions

### DIFF
--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -8,6 +8,7 @@ import datetime
 from cookiecutter.utils import rmtree
 
 from click.testing import CliRunner
+from pytest import raises
 
 import importlib
 
@@ -296,40 +297,50 @@ def test_bake_with_argparse_console_script_files(cookies):
 def test_bake_with_console_script_cli(cookies):
     context = {'command_line_interface': 'click'}
     result = cookies.bake(extra_context=context)
+
     project_path, project_slug, project_dir = project_info(result)
+    cli_file_path = result.project.join('/'.join([project_slug, "cli.py"]))
+    assert "import click" in cli_file_path.read()
+
     module_path = os.path.join(project_dir, 'cli.py')
     module_name = '.'.join([project_slug, 'cli'])
     spec = importlib.util.spec_from_file_location(module_name, module_path)
     cli = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(cli)
     runner = CliRunner()
+
     noarg_result = runner.invoke(cli.main)
     assert noarg_result.exit_code == 0
     noarg_output = ' '.join([
         'Replace this message by putting your code into',
         project_slug])
     assert noarg_output in noarg_result.output
+
     help_result = runner.invoke(cli.main, ['--help'])
     assert help_result.exit_code == 0
     assert 'Show this message' in help_result.output
 
 
-def test_bake_with_argparse_console_script_cli(cookies):
-    context = {'command_line_interface': 'argparse'}
+def test_bake_with_argparse_console_script_cli(cookies, capsys):
+    context = {'command_line_interface': 'Argparse'}
     result = cookies.bake(extra_context=context)
+
     project_path, project_slug, project_dir = project_info(result)
+    cli_file_path = result.project.join('/'.join([project_slug, "cli.py"]))
+    assert "import argparse" in cli_file_path.read()
+
     module_path = os.path.join(project_dir, 'cli.py')
     module_name = '.'.join([project_slug, 'cli'])
     spec = importlib.util.spec_from_file_location(module_name, module_path)
     cli = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(cli)
-    runner = CliRunner()
-    noarg_result = runner.invoke(cli.main)
-    assert noarg_result.exit_code == 0
+
+    cli.main()  # type: ignore
     noarg_output = ' '.join([
         'Replace this message by putting your code into',
         project_slug])
-    assert noarg_output in noarg_result.output
-    help_result = runner.invoke(cli.main, ['--help'])
-    assert help_result.exit_code == 0
-    assert 'Show this message' in help_result.output
+    assert noarg_output in capsys.readouterr().out
+
+    with raises(SystemExit):
+        cli.main(["--help"])  # type: ignore
+    assert "show this help message" in capsys.readouterr().out

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/cli.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/cli.py
@@ -18,11 +18,11 @@ def main(args=None):
     return 0
 {%- endif %}
 {%- if cookiecutter.command_line_interface|lower == 'argparse' %}
-def main():
+def main(args=None):
     """Console script for {{cookiecutter.project_slug}}."""
     parser = argparse.ArgumentParser()
     parser.add_argument('_', nargs='*')
-    args = parser.parse_args()
+    args = parser.parse_args(args=args)
 
     print("Arguments: " + str(args._))
     print("Replace this message by putting your code into "


### PR DESCRIPTION
Fixes issue #588.

There was a typo in the unit test. `pytest-cookies` is case sensitive so
using `argparse` would actually make use of the click library in the
generated template.