### PR TITLE
TST,BLD: require pytest-cov, latest versions of pytest,pytest-cov,pyest-runner

### DIFF
--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -52,7 +52,7 @@ lint: ## check style with flake8
 
 test: ## run tests quickly with the default Python
 {%- if cookiecutter.use_pytest == 'y' %}
-	pytest
+	pytest -v --cov={{ cookiecutter.project_slug }} --cov-report=term-missing
 {%- else %}
 	python setup.py test
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/requirements_dev.txt
+++ b/{{cookiecutter.project_slug}}/requirements_dev.txt
@@ -4,11 +4,12 @@ wheel==0.33.6
 watchdog==0.9.0
 flake8==3.7.8
 tox==3.14.0
-coverage==4.5.4
+coverage==5.2
 Sphinx==1.8.5
 twine==1.14.0
 {% if cookiecutter.command_line_interface|lower == 'click' -%}
 Click==7.0{% endif %}
 {% if cookiecutter.use_pytest == 'y' -%}
-pytest==4.6.5
-pytest-runner==5.1{% endif %}
+pytest==5.4.3
+pytest-cov==2.10.0
+pytest-runner==5.2{% endif %}

--- a/{{cookiecutter.project_slug}}/setup.py
+++ b/{{cookiecutter.project_slug}}/setup.py
@@ -14,7 +14,7 @@ requirements = [{%- if cookiecutter.command_line_interface|lower == 'click' %}'C
 
 setup_requirements = [{%- if cookiecutter.use_pytest == 'y' %}'pytest-runner',{%- endif %} ]
 
-test_requirements = [{%- if cookiecutter.use_pytest == 'y' %}'pytest>=3',{%- endif %} ]
+test_requirements = [{%- if cookiecutter.use_pytest == 'y' %}'pytest-cov>=2.10.0',{%- endif %} ]
 
 {%- set license_classifiers = {
     'MIT license': 'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
This adds a dev requirement for pytest-cov (coverage is already required); which adds support for the `pytest --cov= --cov-report=` options.

I also added the verbose pytest flag to the Makefile because the test output is so much more helpful; that's something I could obviously opinionatedly add to derivatives of this excellent cookiecutter.

In checking only the pytest-related package versions on pypi against those in requirements_dev:
- I noticed that there are newer versions and just changed all to current. Hopefully there's no version conflict.
- I noticed that pytest-runner now says pytest-runner is bad and wrong and just use tox. I basically always just run `make test` and never `python setup.py pytest` anyway, so.
  https://pypi.org/project/pytest-runner/
