### PR TITLE
Add pyYAML to requirements_dev.txt

### DIFF
--- a/{{cookiecutter.project_slug}}/requirements_dev.txt
+++ b/{{cookiecutter.project_slug}}/requirements_dev.txt
@@ -12,3 +12,4 @@ Click==7.0{% endif %}
 {% if cookiecutter.use_pytest == 'y' -%}
 pytest==4.6.5
 pytest-runner==5.1{% endif %}
+pyYAML==5.3.1


### PR DESCRIPTION
`make servedocs` needs pyYAML, without pyYAML we get the following:
```
The HTML pages are in _build/html.
make[1]: Leaving directory '/home/hpar/Documents/tasks3/docs'
python -c "$BROWSER_PYSCRIPT" docs/_build/html/index.html
watchmedo shell-command -p '*.rst' -c 'make -C docs html' -R -D .
Traceback (most recent call last):
  File "/home/hpar/Documents/tasks3/env/bin/watchmedo", line 5, in <module>
    from watchdog.watchmedo import main
  File "/home/hpar/Documents/tasks3/env/lib/python3.8/site-packages/watchdog/watchmedo.py", line 27, in <module>
    import yaml
ModuleNotFoundError: No module named 'yaml'
make: *** [Makefile:74: servedocs] Error 1
```